### PR TITLE
[feat] 모바일 내비게이션과 분석 화면을 개선했어요

### DIFF
--- a/src/features/analyze/components/SampleChoiceBox.jsx
+++ b/src/features/analyze/components/SampleChoiceBox.jsx
@@ -29,19 +29,19 @@ export default function SampleChoiceBox({ onPick, picking }) {
     }
 
     return (
-        <div className="mt-8 flex items-center justify-between gap-3 rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <div className="mt-8 flex flex-col gap-4 rounded-xl border border-slate-200 bg-slate-50 p-4 sm:flex-row sm:items-center sm:justify-between">
             {/* 왼쪽 문구 */}
-            <p className="m-0 min-w-0 flex-1 text-sm text-slate-600">
+            <p className="m-0 min-w-0 text-center text-sm text-slate-600 sm:flex-1 sm:text-left">
                 파일이 없어도 괜찮아요. 준비된{" "}
                 <span className="font-medium text-slate-800">샘플 파일</span>로
                 바로 테스트할 수 있어요.
             </p>
 
             {/* 오른쪽 컨테이너: 고정 폭 + 오버플로우 표시 */}
-            <div className="relative min-h-[28px] w-[260px] flex-shrink-0 overflow-visible">
+            <div className="relative min-h-[28px] mt-1 flex w-full flex-shrink-0 overflow-visible sm:mt-0 sm:w-[260px]">
                 {/* 1) 초기: '사용할게요' 버튼 (오른쪽 끝 정렬) */}
                 <div
-                    className={`absolute inset-0 z-10 flex items-center justify-end gap-2 transition-opacity duration-700 ease-in-out ${
+                    className={`absolute inset-0 z-10 flex items-center justify-center gap-2 transition-opacity duration-700 ease-in-out sm:justify-end ${
                         showSamples || phase !== "idle" ? "pointer-events-none opacity-0" : "opacity-100"
                     }`}
                 >
@@ -56,7 +56,7 @@ export default function SampleChoiceBox({ onPick, picking }) {
 
                 {/* 2) 샘플 선택 버튼 (이미지/비디오) */}
                 <div
-                    className={`absolute inset-0 z-10 flex flex-nowrap items-center justify-end gap-2 transition-opacity duration-700 ease-in-out ${
+                    className={`absolute inset-0 z-10 flex flex-nowrap items-center justify-center gap-2 transition-opacity duration-700 ease-in-out sm:justify-end ${
                         phase === "options" ? "opacity-100" : "pointer-events-none opacity-0"
                     }`}
                 >
@@ -80,7 +80,7 @@ export default function SampleChoiceBox({ onPick, picking }) {
 
                 {/* 3) 상태 배지: 업로드 중 (옵션이 사라진 뒤 약간 늦게 등장하도록 delay) */}
                 <div
-                    className={`absolute inset-0 z-10 flex items-center justify-end transition-opacity duration-1000 ease-in-out ${
+                    className={`absolute inset-0 z-10 flex items-center justify-center transition-opacity duration-1000 ease-in-out sm:justify-end ${
                         phase === "loading" ? "opacity-100 delay-100" : "pointer-events-none opacity-0"
                     }`}
                 >
@@ -100,7 +100,7 @@ export default function SampleChoiceBox({ onPick, picking }) {
 
                 {/* 4) 상태 배지: 확인 요청 */}
                 <div
-                    className={`absolute inset-0 z-10 flex items-center justify-end transition-opacity duration-1000 ease-in-out ${
+                    className={`absolute inset-0 z-10 flex items-center justify-center transition-opacity duration-1000 ease-in-out sm:justify-end ${
                         phase === "done" ? "opacity-100" : "pointer-events-none opacity-0"
                     }`}
                 >

--- a/src/features/navigation/components/avatarButton.js
+++ b/src/features/navigation/components/avatarButton.js
@@ -13,7 +13,18 @@ import {ChevronDownIcon} from "@heroicons/react/20/solid";
 import LanguageMenu from "./LanguageMenu";
 import { useTranslation } from 'react-i18next';
 
-export default function AvatarButton() {
+const BUTTON_DIMENSIONS = {
+    sm: {
+        button: "w-10 h-10",
+        icon: "w-7 h-7",
+    },
+    md: {
+        button: "w-12 h-12",
+        icon: "w-8 h-8",
+    },
+};
+
+export default function AvatarButton({ size = "md" }) {
     const { logout, userInfo } = useAuth();
     const navigate = useNavigate();
     const location = useLocation();
@@ -54,18 +65,20 @@ export default function AvatarButton() {
     const displayName = userInfo?.nickname || userInfo?.userId || "User";
     const displayEmail = userInfo?.userId || "";
 
+    const { button: buttonSizeClass, icon: iconSizeClass } = BUTTON_DIMENSIONS[size] || BUTTON_DIMENSIONS.md;
+
     return (
         <Menu as="div" className="relative">
             <div>
                 <MenuButton>
                     <button
                         type="button"
-                        className="relative inline-flex items-center justify-center w-12 h-12 -my-1
+                        className={`relative inline-flex items-center justify-center ${buttonSizeClass} -my-1
              rounded-full border-2 border-gray-300 bg-indigo-500
              text-white hover:bg-indigo-600 hover:border-indigo-600
-             transition-colors duration-200"
+             transition-colors duration-200`}
                     >
-                        <UserIcon className="w-8 h-8" aria-hidden="true" />
+                        <UserIcon className={iconSizeClass} aria-hidden="true" />
                     </button>
                 </MenuButton>
             </div>

--- a/src/features/navigation/components/mobileNavigationAuthButton.js
+++ b/src/features/navigation/components/mobileNavigationAuthButton.js
@@ -4,10 +4,20 @@ import {Link, useNavigate} from "react-router-dom";
 import {useAuth} from "providers/authProvider";
 
 
-export default function MobileNavigationAuthButton() {
+export default function MobileNavigationAuthButton({ localePrefix = "", onNavigate }) {
     const [isLoggedIn, setIsLoggedIn] = useState(false);
     const { accessToken, logout } = useAuth();
     const navigate = useNavigate();
+
+    const buildPath = (suffix) => {
+        if (!suffix.startsWith("/")) {
+            suffix = `/${suffix}`;
+        }
+        return localePrefix ? `${localePrefix}${suffix}` : suffix;
+    };
+
+    const loginPath = buildPath("/login");
+    const dashboardPath = buildPath("/dashboard");
 
     useEffect(() => {
         // 페이지 로드될 때 토큰 확인
@@ -18,30 +28,45 @@ export default function MobileNavigationAuthButton() {
         }
     }, [accessToken]);
 
-    {/*<a*/}
-    {/*    href="#"*/}
-    {/*    className="-mx-3 block rounded-lg px-3 py-2.5 text-base/7 font-semibold text-gray-900 hover:bg-gray-50"*/}
-    {/*>*/}
-    {/*    Log in*/}
-    {/*</a>*/}
+    const handleLogout = () => {
+        logout();
+        if (typeof onNavigate === "function") onNavigate();
+    };
+
+    const handleDashboard = (event) => {
+        event.preventDefault();
+        if (typeof onNavigate === "function") onNavigate();
+        navigate(dashboardPath);
+    };
 
     return (
-        <>
+        <div className="space-y-2">
             {isLoggedIn ? (
                 <>
-                    <div className="mb-2 rounded-lg py-2.5 px-3 -mx-3  text-sm/6 text-gray-600  ring-gray-900/10 hover:bg-gray-50">
-                        <a href="#" className="font-semibold text-indigo-600">View Dashboard</a>
-                    </div>
-                    <Link className="my-2 -mx-3 px-3 py-2.5 block rounded-lg text-base/7 font-semibold text-gray-900 hover:bg-gray-50" onClick={logout}>
+                    <button
+                        type="button"
+                        onClick={handleDashboard}
+                        className="w-full rounded-xl border border-indigo-200 bg-indigo-50 px-4 py-3 text-base font-semibold text-indigo-700 shadow-sm transition hover:bg-indigo-100"
+                    >
+                        View Dashboard
+                    </button>
+                    <button
+                        type="button"
+                        onClick={handleLogout}
+                        className="w-full rounded-xl border border-slate-200 px-4 py-3 text-base font-semibold text-slate-600 transition hover:border-rose-200 hover:text-rose-600 hover:bg-rose-50"
+                    >
                         Log out <span aria-hidden="true">&rarr;</span>
-                    </Link>
+                    </button>
                 </>
-
             ) : (
-                <Link className="my-2 -mx-3 px-3 py-2.5 block rounded-lg text-base/7 font-semibold text-gray-900 hover:bg-gray-50" to="/login">
-                    Log in <span aria-hidden="true">&rarr;</span>
+                <Link
+                    to={loginPath}
+                    onClick={() => typeof onNavigate === "function" && onNavigate()}
+                    className="flex w-full items-center justify-center rounded-xl bg-indigo-600 px-4 py-3 text-base font-semibold text-white shadow-sm transition hover:bg-indigo-700"
+                >
+                    Log in <span aria-hidden="true" className="ml-1">&rarr;</span>
                 </Link>
             )}
-        </>
+        </div>
     );
 }

--- a/src/features/navigation/components/navigationAuthButton.js
+++ b/src/features/navigation/components/navigationAuthButton.js
@@ -2,7 +2,6 @@ import React, {useEffect, useState} from "react";
 import {Link, useNavigate} from "react-router-dom";
 
 import {useAuth} from "providers/authProvider";
-import avatar from "assets/1.jpg";
 import AvatarButton from "./avatarButton";
 
 export default function NavigationAuthButton() {
@@ -20,17 +19,17 @@ export default function NavigationAuthButton() {
     }, [accessToken]);
 
     return (
-        <nav className="flex justify-end gap-4 p-4">
+        <div className="flex items-center justify-end gap-3">
             {isLoggedIn ? (
-                    <AvatarButton />
+                <AvatarButton />
             ) : (
                 <Link
                     to="/login"
-                    className="block px-3 py-2 text-xs font-semibold text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded transition"
+                    className="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 hover:bg-indigo-50"
                 >
                     Log in <span aria-hidden="true">&rarr;</span>
                 </Link>
             )}
-        </nav>
+        </div>
     );
 }

--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -1,75 +1,37 @@
-import React, {Fragment, useEffect, useMemo} from 'react';
-import {Link, useLocation, useNavigate} from "react-router-dom";
-import { useState } from 'react';
-import { ChevronDownIcon, PhoneIcon, PlayCircleIcon } from '@heroicons/react/20/solid'
-import {
-    Dialog,
-    DialogPanel,
-    Disclosure,
-    DisclosureButton,
-    DisclosurePanel,
-    Popover,
-    PopoverButton,
-    PopoverGroup,
-    PopoverPanel, Transition,
-} from '@headlessui/react'
-import {
-    ArrowPathIcon,
-    Bars3Icon,
-    ChartPieIcon,
-    CursorArrowRaysIcon,
-    FingerPrintIcon,
-    SquaresPlusIcon,
-    XMarkIcon,
-} from '@heroicons/react/24/outline'
+import React, { Fragment, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import { PopoverGroup, Transition } from '@headlessui/react';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 
-import {useAuth} from "providers/authProvider";
-import Logo from "assets/logo.svg";
-import NavigationAuthButton from "features/navigation/components/navigationAuthButton";
-import MobileNavigationAuthButton from "features/navigation/components/mobileNavigationAuthButton";
-
-
-const products = [
-    { name: 'Analytics', description: 'Get a better understanding of your traffic', href: '#', icon: ChartPieIcon },
-    { name: 'Engagement', description: 'Speak directly to your customers', href: '#', icon: CursorArrowRaysIcon },
-    { name: 'Security', description: 'Your customers\' data will be safe and secure', href: '#', icon: FingerPrintIcon },
-    { name: 'Integrations', description: 'Connect with third-party tools', href: '#', icon: SquaresPlusIcon },
-    { name: 'Automations', description: 'Build strategic funnels that will convert', href: '#', icon: ArrowPathIcon },
-]
-const callsToAction = [
-    { name: 'Watch demo', href: '#', icon: PlayCircleIcon },
-    { name: 'Contact sales', href: '#', icon: PhoneIcon },
-]
+import { useAuth } from 'providers/authProvider';
+import NavigationAuthButton from 'features/navigation/components/navigationAuthButton';
+import MobileNavigationAuthButton from 'features/navigation/components/mobileNavigationAuthButton';
+import AvatarButton from 'features/navigation/components/avatarButton';
 
 const Navigation = () => {
-    const { userInfo, logout, loading} = useAuth();
-    const [clicked, setClicked] = useState(false);
-    const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
+    const { userInfo } = useAuth();
+    const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+    const [shrink, setShrink] = useState(0);
+    const [navHeight, setNavHeight] = useState(72);
+    const navRef = useRef(null);
 
     const navigate = useNavigate();
     const location = useLocation();
     const localeMatch = location.pathname.match(/^\/([a-zA-Z-]{2,5})(?=\/|$)/);
     const localePrefix = localeMatch ? `/${localeMatch[1]}` : '';
+
     const navItems = useMemo(() => ([
-        { key: 'analyze', label: 'Analyze', to: `${localePrefix}/analyze`, path: '/analyze' },
-        { key: 'features', label: 'Features', to: `${localePrefix}/feature`, path: '/feature' },
-        { key: 'pricing', label: 'Pricing', to: `${localePrefix}/pricing`, path: '/pricing' },
-        { key: 'docs', label: 'Docs', to: `${localePrefix}/docs`, path: '/docs' },
-        { key: 'blog', label: 'Blog', to: `${localePrefix}/blog`, path: '/blog', hash: '#blog' },
-        { key: 'support', label: 'Support', to: `${localePrefix}/support`, path: '/support' },
+        { key: 'analyze', label: 'Analyze', to: localePrefix ? `${localePrefix}/analyze` : '/analyze', path: '/analyze' },
+        { key: 'features', label: 'Features', to: localePrefix ? `${localePrefix}/feature` : '/feature', path: '/feature' },
+        { key: 'pricing', label: 'Pricing', to: localePrefix ? `${localePrefix}/pricing` : '/pricing', path: '/pricing' },
+        { key: 'docs', label: 'Docs', to: localePrefix ? `${localePrefix}/docs` : '/docs', path: '/docs' },
+        { key: 'blog', label: 'Blog', to: localePrefix ? `${localePrefix}/blog` : '/blog', path: '/blog', hash: '#blog' },
+        { key: 'support', label: 'Support', to: localePrefix ? `${localePrefix}/support` : '/support', path: '/support' },
     ]), [localePrefix]);
 
-    const handleClick = () => {
-        if (userInfo) {
-            alert(`환영합니다. ${userInfo.userId}`);
-            setClicked(true);
-        }
-    };
-    const [scrolled, setScrolled] = useState(false);
-    const [shrink, setShrink] = useState(0); // 0 ~ 1
     useEffect(() => {
         let ticking = false;
-        const max = 120; // px range to fully shrink
+        const max = 120;
         const onScroll = () => {
             if (ticking) return;
             ticking = true;
@@ -77,7 +39,6 @@ const Navigation = () => {
                 const y = window.scrollY || 0;
                 const p = Math.max(0, Math.min(1, y / max));
                 setShrink(p);
-                setScrolled(p > 0.02);
                 ticking = false;
             });
         };
@@ -85,6 +46,32 @@ const Navigation = () => {
         window.addEventListener('scroll', onScroll, { passive: true });
         return () => window.removeEventListener('scroll', onScroll);
     }, []);
+
+    useLayoutEffect(() => {
+        if (typeof window === 'undefined') return undefined;
+        const updateHeight = () => {
+            if (navRef.current) {
+                const rect = navRef.current.getBoundingClientRect();
+                setNavHeight(rect.height);
+            }
+        };
+        updateHeight();
+        window.addEventListener('resize', updateHeight);
+        return () => window.removeEventListener('resize', updateHeight);
+    }, [shrink]);
+
+    useEffect(() => {
+        setMobileMenuOpen(false);
+    }, [location.pathname, location.search]);
+
+    useEffect(() => {
+        if (!mobileMenuOpen || typeof document === 'undefined') return undefined;
+        const original = document.body.style.overflow;
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.body.style.overflow = original;
+        };
+    }, [mobileMenuOpen]);
 
     const headerStyle = useMemo(() => {
         const lerp = (a, b, t) => a + (b - a) * t;
@@ -126,17 +113,6 @@ const Navigation = () => {
         return normalized || '/';
     };
 
-    const getTargetPath = (to) => {
-        if (typeof to === 'string') {
-            return to.split(/[?#]/)[0] || '/';
-        }
-        if (to && typeof to === 'object') {
-            const candidate = to.pathname || '/';
-            return candidate.split(/[?#]/)[0] || '/';
-        }
-        return '/';
-    };
-
     const currentPath = normalizePath(location.pathname);
     const currentHash = location.hash || '';
 
@@ -159,150 +135,199 @@ const Navigation = () => {
         return Number.isFinite(eased) ? eased : 0;
     }, [shrink]);
 
+    const isLoggedIn = Boolean(userInfo);
+    const displayName = userInfo?.nickname || userInfo?.userId || '';
+    const displayEmail = userInfo?.userId || '';
+    const userInitials = useMemo(() => {
+        const src = displayName || displayEmail || 'U';
+        const trimmed = (src || '').trim();
+        if (!trimmed) return 'U';
+        const letters = trimmed.replace(/[^A-Za-z0-9가-힣]/g, '');
+        return letters.slice(0, 1).toUpperCase() || 'U';
+    }, [displayName, displayEmail]);
+
+    const loginPath = localePrefix ? `${localePrefix}/login` : '/login';
+    const freeTrialPath = localePrefix ? `${localePrefix}/free-trial` : '/free-trial';
+
+    const buildLinkTarget = (item) => {
+        if (item.hash) {
+            return { pathname: item.to, hash: item.hash };
+        }
+        return item.to;
+    };
+
     return (
         <header
-            className={`fixed inset-x-0 top-0 z-30 transition-[padding,top,border-radius,transform,background,backdrop-filter,box-shadow,left,right] duration-400 ease-out`}
+            className="fixed inset-x-0 top-0 z-40 transition-[padding,top,border-radius,transform,background,backdrop-filter,box-shadow,left,right] duration-400 ease-out"
             style={headerStyle}
         >
-            <nav aria-label="Global" className={`mx-auto flex items-center justify-between px-6 lg:px-8 py-3`} style={{ paddingBlock: `${(12 - 8*shrink).toFixed(1)}px`, paddingInline: `${(24 - 8*shrink).toFixed(1)}px` }}>
-                <div className="flex items-center gap-x-10 lg:flex-1">
-                    <a href="/" className="-m-1.5 p-1.5 relative z-20 mr-6">
-                        <span className="sr-only">gravifox</span>
-                        <div className="flex justify-center">
-                            <h1
-                                onClick={() => navigate("/")}
-                                translate="no"
-                                className="cursor-pointer select-none text-[clamp(14px,2.8vw,26px)] font-extrabold tracking-tight leading-none text-indigo-500 drop-shadow-md"
-                            >
-                                GRAVIFOX.
-                            </h1>
-                        </div>
-                    </a>
-                    <PopoverGroup className="hidden lg:flex lg:gap-x-8 pt-0.5">
-                        {navItems.map((item) => {
-                            const isActive = activeItemKey === item.key;
-                            const highlightLevel = isActive ? highlightStrength : 0;
-                            const showHighlight = highlightLevel > 0;
-                            const linkClasses = `group relative inline-flex text-[1.05rem] font-bold tracking-wide transition-colors duration-200 ${isActive ? 'text-indigo-600' : 'text-gray-700 hover:text-gray-900'}`;
-                            const pillClasses = `inline-flex items-center justify-center rounded-full border px-3.5 py-1.5 text-current transition-all duration-300 leading-tight ${showHighlight ? 'bg-indigo-50/90 border-indigo-200' : 'border-transparent group-hover:border-indigo-100 group-hover:bg-indigo-50/70'}`;
-                            const highlightStyle = showHighlight
-                                ? {
-                                    boxShadow: `0 12px 28px -18px rgba(79, 70, 229, ${(0.35 + 0.2 * highlightLevel).toFixed(2)})`,
-                                    borderColor: `rgba(129, 140, 248, ${(0.6 + 0.25 * highlightLevel).toFixed(2)})`,
-                                    backgroundColor: `rgba(238, 242, 255, ${(0.9 + 0.08 * highlightLevel).toFixed(2)})`,
-                                }
-                                : undefined;
-
-                            return (
-                                <Link key={item.key} to={item.to} className={linkClasses}>
-                                    <span className={pillClasses} style={highlightStyle}>
-                                        {item.label}
-                                    </span>
-                                </Link>
-                            );
-                        })}
-                    </PopoverGroup>
-                </div>
-                <div className="flex lg:hidden relative z-20">
-                    <button
-                        type="button"
-                        onClick={() => setMobileMenuOpen(true)}
-                        className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
-                    >
-                        <span className="sr-only">Open main menu</span>
-                        <Bars3Icon aria-hidden="true" className="size-6"/>
-                    </button>
-                </div>
-                <div className="hidden lg:flex lg:flex-1 lg:justify-end">
-                    <NavigationAuthButton/>
-                </div>
-            </nav>
-            <Transition show={mobileMenuOpen} as={Fragment}>
-                <Dialog onClose={setMobileMenuOpen} className="lg:hidden z-30" static>
-                    <Transition.Child
-                        as={Fragment}
-                        enter="transition-opacity duration-300 ease-out"
-                        enterFrom="opacity-0"
-                        enterTo="opacity-100"
-                        leave="transition-opacity duration-200 ease-in"
-                        leaveFrom="opacity-100"
-                        leaveTo="opacity-0"
-                    >
-                        <div className="fixed inset-0 z-10 bg-black/25"/>
-                    </Transition.Child>
-
-                    <Transition.Child
-                        as={Fragment}
-                        enter="transition ease-out duration-1000 transform"
-                        enterFrom="translate-x-full"
-                        enterTo="translate-x-0"
-                        leave="transition ease-in duration-1000 transform"
-                        leaveFrom="translate-x-0"
-                        leaveTo="translate-x-full"
-                    >
-                        <DialogPanel
-                            className=" fixed inset-y-0 right-0 z-30 w-full bg-white px-6 py-6 sm:max-w-sm sm:ring-1 sm:ring-gray-900/10 overflow-y-auto overscroll-none">
-                            <div className="flex items-center justify-between">
-                                <a href="/" className="-m-1.5 p-1.5">
-                                    <span className="sr-only">gravifox</span>
-                                    <img className="h-6 w-auto" src={Logo} alt="gravifox"/>
-                                </a>
-                                <button
-                                    type="button"
-                                    onClick={() => setMobileMenuOpen(false)}
-                                    className="-m-2.5 rounded-md p-2.5 text-gray-700"
+            <div className="relative">
+                <nav
+                    ref={navRef}
+                    aria-label="Global"
+                    className="mx-auto flex items-center justify-between px-6 py-4 lg:px-8"
+                    style={{ paddingBlock: `${(16 - 6 * shrink).toFixed(1)}px`, paddingInline: `${(24 - 8 * shrink).toFixed(1)}px` }}
+                >
+                    <div className="flex items-center gap-x-6 lg:gap-x-10 lg:flex-1">
+                        <a href="/" className="-m-1.5 p-1.5 relative z-20 mr-4 lg:mr-6">
+                            <span className="sr-only">gravifox</span>
+                            <div className="flex justify-center">
+                                <h1
+                                    onClick={() => navigate('/')}
+                                    translate="no"
+                                    className="cursor-pointer select-none text-[clamp(16px,3vw,28px)] font-extrabold tracking-tight leading-none text-indigo-500 drop-shadow-md"
                                 >
-                                    <span className="sr-only">Close menu</span>
-                                    <XMarkIcon aria-hidden="true" className="size-6"/>
-                                </button>
+                                    GRAVIFOX.
+                                </h1>
                             </div>
-                            <div className="mt-6 flow-root">
-                                <div className="-my-6 divide-y divide-gray-500/10">
-                                    <div className="space-y-2 py-6">
-                                        <Disclosure as="div" className="-mx-3">
-                                            <DisclosureButton
-                                                className="group flex w-full items-center justify-between rounded-lg py-2 pr-3.5 pl-3 text-base/7 font-semibold text-gray-900 hover:bg-gray-50">
-                                                Product
-                                                <ChevronDownIcon aria-hidden="true"
-                                                                 className="size-5 flex-none group-data-open:rotate-180"/>
-                                            </DisclosureButton>
-                                            <DisclosurePanel className="mt-2 space-y-2">
-                                                {[...products, ...callsToAction].map((item) => (
-                                                    <DisclosureButton
-                                                        key={item.name}
-                                                        as="a"
-                                                        href={item.href}
-                                                        className="block rounded-lg py-2 pr-3 pl-6 text-sm/7 font-semibold text-gray-900 hover:bg-gray-50"
-                                                    >
-                                                        {item.name}
-                                                    </DisclosureButton>
-                                                ))}
-                                            </DisclosurePanel>
-                                        </Disclosure>
+                        </a>
+                        <PopoverGroup className="hidden lg:flex lg:gap-x-8 pt-0.5">
+                            {navItems.map((item) => {
+                                const isActive = activeItemKey === item.key;
+                                const highlightLevel = isActive ? highlightStrength : 0;
+                                const showHighlight = highlightLevel > 0;
+                                const linkClasses = `group relative inline-flex text-[1.05rem] font-bold tracking-wide transition-colors duration-200 ${isActive ? 'text-indigo-600' : 'text-gray-700 hover:text-gray-900'}`;
+                                const pillClasses = `inline-flex items-center justify-center rounded-full border px-3.5 py-1.5 text-current transition-all duration-300 leading-tight ${showHighlight ? 'bg-indigo-50/90 border-indigo-200' : 'border-transparent group-hover:border-indigo-100 group-hover:bg-indigo-50/70'}`;
+                                const highlightStyle = showHighlight
+                                    ? {
+                                          boxShadow: `0 12px 28px -18px rgba(79, 70, 229, ${(0.35 + 0.2 * highlightLevel).toFixed(2)})`,
+                                          borderColor: `rgba(129, 140, 248, ${(0.6 + 0.25 * highlightLevel).toFixed(2)})`,
+                                          backgroundColor: `rgba(238, 242, 255, ${(0.9 + 0.08 * highlightLevel).toFixed(2)})`,
+                                      }
+                                    : undefined;
+
+                                return (
+                                    <Link key={item.key} to={buildLinkTarget(item)} className={linkClasses}>
+                                        <span className={pillClasses} style={highlightStyle}>
+                                            {item.label}
+                                        </span>
+                                    </Link>
+                                );
+                            })}
+                        </PopoverGroup>
+                    </div>
+                    <div className="flex items-center gap-3 lg:hidden relative z-20">
+                        {isLoggedIn ? (
+                            <AvatarButton size="sm" />
+                        ) : (
+                            <Link
+                                to={loginPath}
+                                className="rounded-full border border-slate-200 px-4 py-2 text-sm font-semibold text-slate-600 transition hover:border-indigo-200 hover:text-indigo-600 hover:bg-indigo-50"
+                            >
+                                Log in
+                            </Link>
+                        )}
+                        <button
+                            type="button"
+                            onClick={() => setMobileMenuOpen((prev) => !prev)}
+                            className="-m-2.5 inline-flex items-center justify-center rounded-md p-2.5 text-gray-700"
+                            aria-expanded={mobileMenuOpen}
+                        >
+                            <span className="sr-only">{mobileMenuOpen ? 'Close main menu' : 'Open main menu'}</span>
+                            {mobileMenuOpen ? (
+                                <XMarkIcon aria-hidden="true" className="size-6" />
+                            ) : (
+                                <Bars3Icon aria-hidden="true" className="size-6" />
+                            )}
+                        </button>
+                    </div>
+                    <div className="hidden lg:flex lg:flex-1 lg:justify-end">
+                        <NavigationAuthButton />
+                    </div>
+                </nav>
+
+                <Transition show={mobileMenuOpen} as={Fragment}>
+                    <>
+                        <Transition.Child
+                            as={Fragment}
+                            enter="transition-opacity duration-200 ease-out"
+                            enterFrom="opacity-0"
+                            enterTo="opacity-100"
+                            leave="transition-opacity duration-150 ease-in"
+                            leaveFrom="opacity-100"
+                            leaveTo="opacity-0"
+                        >
+                            <div
+                                className="fixed inset-x-0 bottom-0 z-30 bg-slate-900/30 lg:hidden"
+                                style={{ top: `${navHeight}px` }}
+                                onClick={() => setMobileMenuOpen(false)}
+                            />
+                        </Transition.Child>
+
+                        <Transition.Child
+                            as={Fragment}
+                            enter="transition duration-300 ease-out"
+                            enterFrom="-translate-y-3 opacity-0"
+                            enterTo="translate-y-0 opacity-100"
+                            leave="transition duration-200 ease-in"
+                            leaveFrom="translate-y-0 opacity-100"
+                            leaveTo="-translate-y-2 opacity-0"
+                        >
+                            <div
+                                className="fixed inset-x-0 z-40 origin-top lg:hidden"
+                                style={{ top: `${navHeight}px` }}
+                            >
+                                <div className="max-h-[calc(100vh-24px)] overflow-y-auto border-t border-slate-200 bg-white px-6 pb-8 pt-6 shadow-[0_18px_36px_-18px_rgba(15,23,42,0.25)]">
+                                    {isLoggedIn ? (
+                                        <div className="flex items-center gap-3 rounded-2xl bg-indigo-50/70 px-4 py-3 text-slate-700">
+                                            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500 text-sm font-semibold text-white">
+                                                {userInitials}
+                                            </div>
+                                            <div className="min-w-0">
+                                                <p className="truncate text-sm font-semibold text-slate-900">{displayName || 'Welcome back'}</p>
+                                                {displayEmail && (
+                                                    <p className="truncate text-xs text-slate-500">{displayEmail}</p>
+                                                )}
+                                            </div>
+                                        </div>
+                                    ) : (
+                                        <div className="rounded-2xl bg-slate-50 px-4 py-4 text-sm text-slate-600">
+                                            Gravifox 계정으로 로그인하고 분석 결과를 저장하고 관리해 보세요.
+                                        </div>
+                                    )}
+
+                                    <nav className="mt-5 space-y-2">
+                                        {navItems.map((item) => {
+                                            const isActive = activeItemKey === item.key;
+                                            const linkClasses = `flex items-center justify-between rounded-xl px-4 py-3 text-base font-semibold transition ${isActive ? 'bg-indigo-50 text-indigo-600' : 'text-slate-700 hover:bg-slate-50 hover:text-slate-900'}`;
+                                            return (
+                                                <Link
+                                                    key={item.key}
+                                                    to={buildLinkTarget(item)}
+                                                    onClick={() => setMobileMenuOpen(false)}
+                                                    className={linkClasses}
+                                                >
+                                                    <span>{item.label}</span>
+                                                    {isActive && <span className="text-xs font-medium text-indigo-500">현재</span>}
+                                                </Link>
+                                            );
+                                        })}
+                                    </nav>
+
+                                    <div className="mt-6">
                                         <Link
-                                            className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50"
-                                            to="/free-trial">Free Trial</Link>
-                                        <Link
-                                            className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50"
-                                            to="/pricing">Pricing</Link>
-                                        <Link
-                                            className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50"
-                                            to="/api-docs">Docs</Link>
-                                        <Link
-                                            className="-mx-3 block rounded-lg px-3 py-2 text-base/7 font-semibold text-gray-900 hover:bg-gray-50"
-                                            to="/support">Support</Link>
+                                            to={freeTrialPath}
+                                            onClick={() => setMobileMenuOpen(false)}
+                                            className="flex w-full items-center justify-center rounded-xl bg-gradient-to-r from-indigo-500 to-purple-500 px-4 py-3 text-base font-semibold text-white shadow-md transition hover:from-indigo-600 hover:to-purple-600"
+                                        >
+                                            Free Trial
+                                        </Link>
                                     </div>
-                                    <div className="py-8">
-                                        <MobileNavigationAuthButton/>
+
+                                    <div className="mt-6 border-t border-slate-200 pt-6">
+                                        <MobileNavigationAuthButton
+                                            localePrefix={localePrefix}
+                                            onNavigate={() => setMobileMenuOpen(false)}
+                                        />
                                     </div>
                                 </div>
                             </div>
-                        </DialogPanel>
-                    </Transition.Child>
-                </Dialog>
-            </Transition>
+                        </Transition.Child>
+                    </>
+                </Transition>
+            </div>
         </header>
     );
-}
+};
 
 export default Navigation;

--- a/src/pages/AnalyzeResult.js
+++ b/src/pages/AnalyzeResult.js
@@ -205,21 +205,21 @@ export default function AnalyzeResult() {
   return (
     <div className="p-0">
       <Navigation />
-      <div className="mx-auto mt-24 w-full max-w-6xl px-4 sm:px-6 lg:px-8">
-        <div className="mb-4 flex items-center justify-between">
+      <div className="mx-auto mt-28 w-full max-w-6xl px-4 sm:mt-32 sm:px-6 lg:mt-36 lg:px-8">
+        <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <h1 className="text-2xl font-semibold text-slate-600">미디어 분석 완료</h1>
-          <div className="flex items-center gap-2">
+          <div className="flex w-full flex-col gap-2 sm:w-auto sm:flex-row sm:items-center">
             <button
               type="button"
               onClick={() => navigate("/analyze")}
-              className="inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-50"
+              className="inline-flex w-full items-center justify-center rounded-md border border-slate-200 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 sm:w-auto"
             >
               돌아가기
             </button>
             <button
               type="button"
               onClick={() => window.print()}
-              className="inline-flex items-center justify-center rounded-md bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-700"
+              className="inline-flex w-full items-center justify-center rounded-md bg-indigo-600 px-3.5 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-indigo-700 sm:w-auto"
             >
               PDF로 저장
             </button>
@@ -227,16 +227,16 @@ export default function AnalyzeResult() {
         </div>
 
         {summary.total > 0 && (
-          <div className="mb-4">
-            <div className="mx-auto w-full max-w-5xl flex flex-wrap items-center gap-3 rounded-xl border border-slate-200 bg-white p-4 text-sm">
-              <div className="flex items-center gap-2">
+          <div className="mb-6">
+            <div className="mx-auto flex w-full max-w-5xl flex-col gap-3 rounded-xl border border-slate-200 bg-white p-4 text-sm sm:flex-row sm:items-center">
+              <div className="flex flex-wrap items-center gap-2">
                 <span className="rounded-md bg-slate-100 px-2 py-1 text-slate-700">총 {summary.total}</span>
                 <span className="rounded-md bg-indigo-50 px-2 py-1 text-indigo-700">진행 {summary.running}</span>
                 <span className="rounded-md bg-emerald-50 px-2 py-1 text-emerald-700">완료 {summary.done}</span>
                 <span className="rounded-md bg-rose-50 px-2 py-1 text-rose-700">실패 {summary.failed}</span>
               </div>
-              <div className="ml-auto flex items-center gap-2">
-                <div className="h-2 w-40 rounded-full bg-slate-100 overflow-hidden">
+              <div className="flex w-full items-center gap-2 sm:ml-auto sm:w-auto">
+                <div className="h-2 w-full overflow-hidden rounded-full bg-slate-100 sm:w-40">
                   <div className="h-2 rounded-full transition-all" style={{ width: `${summary.pct}%`, background: 'var(--brand)' }} />
                 </div>
                 <span className="text-slate-600">{summary.pct}%</span>
@@ -271,14 +271,14 @@ export default function AnalyzeResult() {
 
               // 진행 중: 파일명 + 우측 멘트(헤더 내부 중앙 정렬)
               return (
-                <div key={jid} className="mx-auto w-full max-w-5xl rounded-xl border border-slate-200 bg-white p-6">
-                  <div className="flex items-center justify-between">
+                <div key={jid} className="mx-auto w-full max-w-5xl rounded-xl border border-slate-200 bg-white p-5">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
                     <div className="min-w-0">
                       {r.fileMeta?.name && (
                         <p className="truncate text-sm font-medium text-slate-800">파일: {r.fileMeta.name}</p>
                       )}
                     </div>
-                    <div className="flex w-48 h-6 items-center justify-end text-right overflow-hidden">
+                    <div className="mt-1 flex h-6 w-full items-center justify-center overflow-hidden text-center sm:mt-0 sm:w-48 sm:justify-end sm:text-right">
                       <LoadingMent stage={r.stage} />
                     </div>
                   </div>
@@ -289,15 +289,17 @@ export default function AnalyzeResult() {
         )}
 
         {ids.length === 0 && (
-          <div className="mt-4 rounded-md border border-slate-200 bg-white p-6 text-sm text-slate-700">
-            유효한 분석 세션이 없어요. 파일을 업로드하고 분석을 시작해주세요.
-            <button
-              type="button"
-              onClick={() => navigate("/analyze")}
-              className="ml-3 inline-flex items-center justify-center rounded-md border border-slate-200 bg-white px-3.5 py-1.5 text-sm font-semibold text-slate-700 hover:bg-slate-50"
-            >
-              업로드 페이지로 이동
-            </button>
+          <div className="mt-6 rounded-md border border-slate-200 bg-white p-6 text-sm text-slate-700">
+            <p className="text-sm text-slate-700">유효한 분석 세션이 없어요. 파일을 업로드하고 분석을 시작해주세요.</p>
+            <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+              <button
+                type="button"
+                onClick={() => navigate("/analyze")}
+                className="inline-flex w-full items-center justify-center rounded-md border border-slate-200 bg-white px-3.5 py-2 text-sm font-semibold text-slate-700 transition hover:bg-slate-50 sm:w-auto"
+              >
+                업로드 페이지로 이동
+              </button>
+            </div>
           </div>
         )}
       </div>

--- a/src/pages/MediaAnalyze.js
+++ b/src/pages/MediaAnalyze.js
@@ -31,7 +31,7 @@ export default function MediaAnalyze() {
             {/* 네비게이션 재사용 */}
             {/** Navigation은 전역 헤더 역할을 하며, 메인과 동일하게 재사용합니다. */}
             <Navigation/>
-            <main className="flex-1 pt-24 sm:pt-28 lg:pt-32 pb-16">
+            <main className="flex-1 pt-28 sm:pt-32 lg:pt-36 pb-16">
                 {/* 본문 카드 */}
                 <HowItWorksSection />
             </main>


### PR DESCRIPTION
## 변경 목적
- 모바일에서도 Analyze와 결과 페이지가 끊김 없이 보이도록 UI를 정비했어요.

## 주요 변경점
- navigation.js에서 모바일 내비게이션을 드롭다운으로 재구성하고 아바타 버튼과 카테고리를 반영했어요.
- SampleChoiceBox와 AnalyzeResult 등의 레이아웃을 모바일 중심으로 다시 배치했어요.
- 모바일 로그인/로그아웃 흐름과 CTA 버튼 스타일을 손봤어요.

## 테스트 결과 요약
- npm test -- --watchAll=false 명령을 실행했지만 react-router-dom 모듈을 찾지 못해 실패했어요.

## 보안·성능 고려사항
- 추가 API 호출이나 민감 정보 노출이 발생하지 않도록 UI 레벨만 변경했어요.

## 관련 이슈 번호
- 없어요

------
https://chatgpt.com/codex/tasks/task_e_68e003707b7c8323bac9cefe51d04721