### PR TITLE
[fix] 아바타 메뉴 버튼 ref 전달 문제를 고쳤어요

### DIFF
--- a/src/features/navigation/components/avatarButton.js
+++ b/src/features/navigation/components/avatarButton.js
@@ -70,16 +70,14 @@ export default function AvatarButton({ size = "md" }) {
     return (
         <Menu as="div" className="relative">
             <div>
-                <MenuButton>
-                    <button
-                        type="button"
-                        className={`relative inline-flex items-center justify-center ${buttonSizeClass} -my-1
+                <MenuButton
+                    type="button"
+                    className={`relative inline-flex items-center justify-center ${buttonSizeClass} -my-1
              rounded-full border-2 border-gray-300 bg-indigo-500
              text-white hover:bg-indigo-600 hover:border-indigo-600
              transition-colors duration-200`}
-                    >
-                        <UserIcon className={iconSizeClass} aria-hidden="true" />
-                    </button>
+                >
+                    <UserIcon className={iconSizeClass} aria-hidden="true" />
                 </MenuButton>
             </div>
 


### PR DESCRIPTION
## 변경 목적
- Headless UI MenuButton에서 ref 전달 누락으로 발생하던 오류를 해결했어요.

## 주요 변경점
- AvatarButton 컴포넌트에서 MenuButton이 직접 버튼 요소를 렌더링하도록 바꿔서 ref가 DOM으로 전달되게 했어요.

## 테스트 결과 요약
- 별도의 자동 테스트를 실행하지 않았어요.

## 보안·성능 고려사항
- 보안이나 성능에 영향을 주는 변경은 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e00e447eac8323b09a48ef6e91fa88