### PR TITLE
[fix] AnimatePresence 경고와 모바일 내비게이션 오류를 해결했어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -237,7 +237,7 @@ const Navigation = () => {
                 </nav>
 
                 <Transition show={mobileMenuOpen} as={Fragment}>
-                    <>
+                    <div className="lg:hidden">
                         <Transition.Child
                             as={Fragment}
                             enter="transition-opacity duration-200 ease-out"
@@ -248,7 +248,7 @@ const Navigation = () => {
                             leaveTo="opacity-0"
                         >
                             <div
-                                className="fixed inset-x-0 bottom-0 z-30 bg-slate-900/30 lg:hidden"
+                                className="fixed inset-x-0 bottom-0 z-30 bg-slate-900/30"
                                 style={{ top: `${navHeight}px` }}
                                 onClick={() => setMobileMenuOpen(false)}
                             />
@@ -264,7 +264,7 @@ const Navigation = () => {
                             leaveTo="-translate-y-2 opacity-0"
                         >
                             <div
-                                className="fixed inset-x-0 z-40 origin-top lg:hidden"
+                                className="fixed inset-x-0 z-40 origin-top"
                                 style={{ top: `${navHeight}px` }}
                             >
                                 <div className="max-h-[calc(100vh-24px)] overflow-y-auto border-t border-slate-200 bg-white px-6 pb-8 pt-6 shadow-[0_18px_36px_-18px_rgba(15,23,42,0.25)]">
@@ -323,7 +323,7 @@ const Navigation = () => {
                                 </div>
                             </div>
                         </Transition.Child>
-                    </>
+                    </div>
                 </Transition>
             </div>
         </header>

--- a/src/routes/routes.js
+++ b/src/routes/routes.js
@@ -111,9 +111,10 @@ function AnimatedRoutes() {
     const location = useLocation();
 
     return (
-        <AnimatePresence mode="wait">
+        <>
             <CanonicalLink />
-            <Routes location={location} key={location.pathname}>
+            <AnimatePresence mode="wait">
+                <Routes location={location} key={location.pathname}>
                 {/* Root -> language prefixed redirect */}
                 <Route path="/" element={<LangRedirect />} />
                 {/* Language-prefixed duplicates */}
@@ -152,8 +153,9 @@ function AnimatedRoutes() {
                 <Route path="/blog" element={<LegacyToLocalized />} />
 
                 <Route path="/*" element={<motion.div><CustomErrorPage status={"404"} /></motion.div>} />
-            </Routes>
-        </AnimatePresence>
+                </Routes>
+            </AnimatePresence>
+        </>
     );
 }
 


### PR DESCRIPTION
## 변경 목적
- 모바일 내비게이션 햄버거 버튼을 눌렀을 때 발생하던 오류를 제거하고, 라우트 전환 시 나타나던 AnimatePresence 경고를 해결했어요.

## 주요 변경점
- `src/routes/routes.js`에서 `AnimatePresence` 안에 하나의 자식만 두도록 구조를 정리해 경고를 없앴어요.
- `src/features/navigation/navigation.js`의 모바일 전환 래퍼를 실제 DOM 노드로 감싸서 Headless UI가 필요한 ref를 전달할 수 있도록 했어요.

## 테스트 결과 요약
- `npm run build`를 실행해서 프로덕션 빌드가 정상적으로 끝나는 것을 확인했어요.

## 보안·성능 고려사항
- 추가적인 보안 또는 성능 이슈는 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e0122bf4a083238d6e18157a4b68cd