### PR TITLE
[fix] 모바일 내비게이션 애니메이션과 경계선을 고쳤어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -95,33 +95,45 @@ const Navigation = () => {
         if (!mobileMenuOpen) return headerStyle;
         return {
             ...headerStyle,
-            left: '0px',
-            right: '0px',
-            borderRadius: headerStyle.borderRadius,
+            transformOrigin: 'top center',
             borderBottomLeftRadius: '0px',
             borderBottomRightRadius: '0px',
-            transform: 'none',
             boxShadow: '0 18px 40px -12px rgba(15,23,42,0.32)',
-            border: '1px solid rgba(226, 232, 240, 0.45)',
+            border: '1px solid rgba(226, 232, 240, 0)',
+            borderLeft: '0px',
+            borderRight: '0px',
+            borderBottom: '0px',
         };
     }, [headerStyle, mobileMenuOpen]);
 
-    const normalizePath = (path) => {
-        if (!path) return '/';
-        const [clean] = path.split(/[?#]/);
-        if (!clean) return '/';
-        const withoutLocale =
-            localePrefix && clean.startsWith(localePrefix)
-                ? clean.slice(localePrefix.length) || '/'
-                : clean;
-        let normalized = withoutLocale.startsWith('/') ? withoutLocale : `/${withoutLocale}`;
-        if (normalized.length > 1) {
-            while (normalized.length > 1 && normalized.endsWith('/')) {
-                normalized = normalized.slice(0, -1);
+    const mobileMenuContainerStyle = useMemo(
+        () => ({
+            top: `${navHeight}px`,
+            left: headerStyle.left ?? '0px',
+            right: headerStyle.right ?? '0px',
+        }),
+        [navHeight, headerStyle.left, headerStyle.right]
+    );
+
+    const normalizePath = useCallback(
+        (path) => {
+            if (!path) return '/';
+            const [clean] = path.split(/[?#]/);
+            if (!clean) return '/';
+            const withoutLocale =
+                localePrefix && clean.startsWith(localePrefix)
+                    ? clean.slice(localePrefix.length) || '/'
+                    : clean;
+            let normalized = withoutLocale.startsWith('/') ? withoutLocale : `/${withoutLocale}`;
+            if (normalized.length > 1) {
+                while (normalized.length > 1 && normalized.endsWith('/')) {
+                    normalized = normalized.slice(0, -1);
+                }
             }
-        }
-        return normalized || '/';
-    }, [localePrefix]);
+            return normalized || '/';
+        },
+        [localePrefix]
+    );
 
     const currentPath = normalizePath(location.pathname);
     const currentHash = location.hash || '';
@@ -259,7 +271,7 @@ const Navigation = () => {
                         >
                             <div
                                 className="pointer-events-none fixed inset-x-0 bottom-0 z-30 bg-slate-900/25 backdrop-blur-[2px]"
-                                style={{ top: `${navHeight}px` }}
+                                style={{ ...mobileMenuContainerStyle, bottom: 0 }}
                             />
                         </Transition.Child>
 
@@ -272,10 +284,7 @@ const Navigation = () => {
                             leaveFrom="translate-y-0 opacity-100"
                             leaveTo="-translate-y-2 opacity-0"
                         >
-                            <div
-                                className="fixed inset-x-0 z-40 origin-top"
-                                style={{ top: `${navHeight}px` }}
-                            >
+                            <div className="fixed inset-x-0 z-40 origin-top" style={mobileMenuContainerStyle}>
                                 <div className="mx-auto max-w-lg max-h-[calc(100vh-24px)] overflow-y-auto border border-slate-200 border-t-0 bg-white px-5 pb-8 pt-6 shadow-[0_22px_48px_-22px_rgba(15,23,42,0.32)] transition-[border-radius] duration-300 ease-out sm:max-w-xl sm:px-6"
                                     style={{ borderBottomLeftRadius: '28px', borderBottomRightRadius: '28px' }}
                                 >


### PR DESCRIPTION
## 변경 목적
- 모바일 메뉴를 열었을 때 헤더가 갑자기 커지고 경계선이 보이는 문제를 해결했어요.
- 중복 선언으로 빌드가 실패하던 `normalizePath` 훅을 안정적으로 만들었어요.

## 주요 변경점
- 모바일 메뉴가 열려도 축소된 헤더 크기와 애니메이션을 유지하고, 좌우 경계선이 나타나지 않도록 스타일을 다듬었어요.
- 헤더 폭에 맞춰 모바일 메뉴 컨테이너 위치를 동기화했어요.
- `normalizePath`를 `useCallback`으로 감싸 중복 선언 오류를 제거했어요.

## 테스트 결과 요약
- `npm run build` 명령을 실행해 프로덕션 빌드가 성공하는지 확인했어요.

## 보안·성능 고려사항
- 스타일과 경로 계산 로직만 수정해 보안 및 성능에 추가 영향은 없어요.

## 관련 이슈 번호
- (없음)


------
https://chatgpt.com/codex/tasks/task_e_68e0970af8e483239e9a46f886329b1b