### PR TITLE
[fix] 모바일 내비게이션 정렬 개선했어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -58,7 +58,7 @@ const Navigation = () => {
         updateHeight();
         window.addEventListener('resize', updateHeight);
         return () => window.removeEventListener('resize', updateHeight);
-    }, [shrink]);
+    }, [shrink, mobileMenuOpen]);
 
     useEffect(() => {
         setMobileMenuOpen(false);
@@ -95,7 +95,10 @@ const Navigation = () => {
         if (!mobileMenuOpen) return headerStyle;
         return {
             ...headerStyle,
+            transform: 'none',
             transformOrigin: 'top center',
+            left: '0px',
+            right: '0px',
             borderBottomLeftRadius: '0px',
             borderBottomRightRadius: '0px',
             boxShadow: '0 18px 40px -12px rgba(15,23,42,0.32)',
@@ -106,14 +109,20 @@ const Navigation = () => {
         };
     }, [headerStyle, mobileMenuOpen]);
 
-    const mobileMenuContainerStyle = useMemo(
-        () => ({
+    const mobileMenuContainerStyle = useMemo(() => {
+        if (mobileMenuOpen) {
+            return {
+                top: `${navHeight}px`,
+                left: '0px',
+                right: '0px',
+            };
+        }
+        return {
             top: `${navHeight}px`,
             left: headerStyle.left ?? '0px',
             right: headerStyle.right ?? '0px',
-        }),
-        [navHeight, headerStyle.left, headerStyle.right]
-    );
+        };
+    }, [navHeight, headerStyle.left, headerStyle.right, mobileMenuOpen]);
 
     const normalizePath = useCallback(
         (path) => {


### PR DESCRIPTION
## 변경 목적
- 모바일 상태에서 헤더가 축소된 뒤 햄버거 버튼을 열면 메뉴 패널이 헤더와 어긋나 보여 자연스럽지 않은 문제를 개선하려고 했어요.

## 주요 변경점
- 모바일 메뉴가 열렸을 때 헤더의 좌우 여백과 스케일을 초기화해서 헤더와 드롭다운 패널 폭이 일치하도록 했어요.
- 모바일 메뉴 컨테이너가 열렸을 때 화면 전체 폭을 차지하도록 계산 로직을 조정했어요.
- 내비게이션 높이 계산이 모바일 메뉴 열림 상태에서도 갱신되도록 의존성을 보강했어요.

## 테스트 결과 요약
- `npm test -- --watchAll=false` 명령을 실행했지만 `react-router-dom` 모듈을 찾지 못해 실패했어요.

## 보안·성능 고려사항
- 보안이나 성능에 영향을 주는 변경은 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e0a7ff22908323b1e1b4af12447ff9