### PR TITLE
[fix] 모바일 내비게이션 패널 정렬을 조정했어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -92,7 +92,12 @@ const Navigation = () => {
     }, [shrink]);
 
     const composedHeaderStyle = useMemo(() => {
-        if (!mobileMenuOpen) return headerStyle;
+        if (!mobileMenuOpen) {
+            return {
+                ...headerStyle,
+                zIndex: 40,
+            };
+        }
         return {
             ...headerStyle,
             transform: 'none',
@@ -106,6 +111,7 @@ const Navigation = () => {
             borderLeft: '0px',
             borderRight: '0px',
             borderBottom: '0px',
+            zIndex: 60,
         };
     }, [headerStyle, mobileMenuOpen]);
 
@@ -280,7 +286,7 @@ const Navigation = () => {
                         >
                             <div
                                 className="pointer-events-none fixed inset-x-0 bottom-0 z-30 bg-slate-900/25 backdrop-blur-[2px]"
-                                style={{ ...mobileMenuContainerStyle, bottom: 0 }}
+                                style={{ ...mobileMenuContainerStyle, bottom: 0, zIndex: 30 }}
                             />
                         </Transition.Child>
 
@@ -293,9 +299,12 @@ const Navigation = () => {
                             leaveFrom="translate-y-0 opacity-100"
                             leaveTo="-translate-y-2 opacity-0"
                         >
-                            <div className="fixed inset-x-0 z-40 origin-top" style={mobileMenuContainerStyle}>
-                                <div className="mx-auto max-w-lg max-h-[calc(100vh-24px)] overflow-y-auto border border-slate-200 border-t-0 bg-white px-5 pb-8 pt-6 shadow-[0_22px_48px_-22px_rgba(15,23,42,0.32)] transition-[border-radius] duration-300 ease-out sm:max-w-xl sm:px-6"
-                                    style={{ borderBottomLeftRadius: '28px', borderBottomRightRadius: '28px' }}
+                            <div
+                                className="fixed inset-x-0 z-40 origin-top-right flex justify-end"
+                                style={{ ...mobileMenuContainerStyle, zIndex: 50 }}
+                            >
+                                <div className="max-h-[calc(100vh-24px)] overflow-y-auto border border-slate-200 border-t-0 bg-white px-5 pb-8 pt-6 shadow-[0_22px_48px_-22px_rgba(15,23,42,0.32)] transition-[border-radius] duration-300 ease-out sm:px-6"
+                                    style={{ borderBottomLeftRadius: '28px', borderBottomRightRadius: '28px', width: 'min(420px, 55vw)' }}
                                 >
                                     {isLoggedIn ? (
                                         <div className="flex items-center gap-3 rounded-2xl bg-indigo-50/70 px-4 py-3 text-slate-700">


### PR DESCRIPTION
## 변경 목적
- 모바일 햄버거 메뉴가 화면 중앙에 크게 표시되던 문제를 고쳐서 내비게이션과 자연스럽게 이어지도록 했어요.

## 주요 변경점
- 모바일 메뉴가 열릴 때 헤더와 패널 z-index를 조정해서 본문 위로 확실히 올라오도록 했어요.
- 모바일 메뉴 컨테이너를 우측 정렬하고 폭을 55vw로 줄여 반응형 패널처럼 보이도록 변경했어요.
- 패널 오버레이와 본문 사이의 z-index를 정리해 겹침 현상이 없도록 했어요.

## 테스트 결과 요약
- 별도의 자동화 테스트를 실행하지 않았어요.

## 보안·성능 고려사항
- 추가적인 보안 이슈나 성능 저하는 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e0ad6f5fb8832395aba9c2bd9be83d