### PR TITLE
[fix] 모바일 메뉴 애니메이션과 문구를 다듬었어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -236,12 +236,13 @@ const Navigation = () => {
                 <Transition
                     show={mobileMenuOpen}
                     as={Fragment}
-                    enter="transition duration-300 ease-out"
-                    enterFrom="-translate-y-3 opacity-0"
-                    enterTo="translate-y-0 opacity-100"
-                    leave="transition duration-200 ease-in"
-                    leaveFrom="translate-y-0 opacity-100"
-                    leaveTo="-translate-y-2 opacity-0"
+                    appear
+                    enter="transform-gpu transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)]"
+                    enterFrom="opacity-0 -translate-y-4 scale-[0.98]"
+                    enterTo="opacity-100 translate-y-0 scale-100"
+                    leave="transform-gpu transition-all duration-250 ease-[cubic-bezier(0.4,0,0.2,1)]"
+                    leaveFrom="opacity-100 translate-y-0 scale-100"
+                    leaveTo="opacity-0 -translate-y-2 scale-[0.98]"
                 >
                     <div className="lg:hidden">
                         <div className="mx-auto px-6 pb-8 pt-2">
@@ -260,7 +261,7 @@ const Navigation = () => {
                                     </div>
                                 ) : (
                                     <div className="rounded-2xl bg-slate-50 px-4 py-4 text-sm text-slate-600">
-                                        Gravifox 계정으로 로그인하고 분석 결과를 저장하고 관리해 보세요.
+                                        지금 가입하고 분석 결과를 한곳에 모아 보세요.
                                     </div>
                                 )}
 


### PR DESCRIPTION
## 변경 목적
- 모바일 햄버거 메뉴가 열리고 닫힐 때 끊기는 애니메이션을 자연스럽게 전환하고 싶었어요.
- 비로그인 사용자를 위한 안내 문구를 간결하게 다듬고 싶었어요.

## 주요 변경점
- 모바일 메뉴 Transition 애니메이션에 등장/퇴장 easing과 scale 효과를 조정했어요.
- 모바일 메뉴 상단의 회원가입 유도 문구를 한 줄짜리 문장으로 바꿨어요.

## 테스트 결과 요약
- 별도의 자동화 테스트를 실행하지 않았어요.

## 보안·성능 고려사항
- 애니메이션 파라미터 수정으로 보안이나 성능에 부정적인 영향은 없어요.

## 관련 이슈 번호
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68e0c2b39158832394913ce36a779188