### PR TITLE
[style] 모바일 내비게이션 애니메이션 조정했어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -237,12 +237,12 @@ const Navigation = () => {
                     show={mobileMenuOpen}
                     as={Fragment}
                     appear
-                    enter="transform-gpu transition-all duration-500 ease-[cubic-bezier(0.22,1,0.36,1)]"
-                    enterFrom="opacity-0 -translate-y-6 scale-[0.96]"
+                    enter="transform-gpu transition-all duration-[1100ms] ease-[cubic-bezier(0.16,1,0.3,1)]"
+                    enterFrom="opacity-0 -translate-y-20 scale-[0.94]"
                     enterTo="opacity-100 translate-y-0 scale-100"
-                    leave="transform-gpu transition-all duration-400 ease-[cubic-bezier(0.4,0,0.2,1)]"
+                    leave="transform-gpu transition-all duration-[900ms] ease-[cubic-bezier(0.7,0,0.84,0)]"
                     leaveFrom="opacity-100 translate-y-0 scale-100"
-                    leaveTo="opacity-0 -translate-y-3 scale-[0.97]"
+                    leaveTo="opacity-0 -translate-y-16 scale-[0.95]"
                 >
                     <div className="lg:hidden origin-top" style={{ willChange: 'transform, opacity' }}>
                         <div className="mx-auto px-6 pb-8 pt-2">


### PR DESCRIPTION
## 변경 목적
- 모바일 내비게이션 메뉴가 열리고 닫힐 때 애니메이션이 너무 빠르게 종료되어 사용자가 변화를 인지하기 어려웠어요.

## 주요 변경점
- `src/features/navigation/navigation.js`에서 모바일 메뉴 트랜지션 속도와 이동 거리를 늘려 아래에서 부드럽게 내려오고 올라가도록 조정했어요.

## 테스트 결과 요약
- 별도의 자동화 테스트를 실행하지 않았어요. (UI 애니메이션 변경)

## 보안·성능 고려사항
- 애니메이션 시간 변경만 포함되어 있어 보안이나 성능에 유의미한 영향이 없어요.

## 관련 이슈 번호
- 해당 사항 없어요.


------
https://chatgpt.com/codex/tasks/task_e_68e0ee6810848323bf33888c94bb1589