### PR TITLE
[feat] 로그인 페이지 UI를 개선했어요

### DIFF
--- a/src/features/login/signInForm.js
+++ b/src/features/login/signInForm.js
@@ -1,19 +1,20 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 
 import LoginErrorMessage from "features/login/loginErrorMessage";
 import SignInAPI from "features/login/api/signInAPI";
-import GoogleLoginButton from "features/login/components/googleLoginButton"
-import {Link, useNavigate} from "react-router-dom";
+import GoogleLoginButton from "features/login/components/googleLoginButton";
+import { Link, useNavigate } from "react-router-dom";
+
 export default function SignInForm() {
     const navigate = useNavigate();
 
     // LoginErrorMessage에 전달하기 위한 에러 코드와 메세지
     const [errorStatus, setErrorStatus] = useState(null),
         [errorMessage, setErrorMessage] = useState(null),
-        {signIn} = SignInAPI(),
+        { signIn } = SignInAPI(),
         [formState, setFormState] = useState({
-            userId: '',
-            password: ''
+            userId: "",
+            password: "",
         });
     /**
      * 로그인 폼 제출시 처리되는 함수입니다. 로그인 요청을 signIn으로 전달하며 입력값은 formstate 입니다.
@@ -24,19 +25,19 @@ export default function SignInForm() {
     const handleSubmit = async (e) => {
         e.preventDefault();
         try {
-            await signIn(formState)
+            await signIn(formState);
         } catch (error) {
-            if (error?.code === 'EMAIL_NOT_VERIFIED') {
-                navigate('/verify', { state: { email: formState.userId } });
+            if (error?.code === "EMAIL_NOT_VERIFIED") {
+                navigate("/verify", { state: { email: formState.userId } });
                 return;
             }
             setErrorStatus(error.status);
             setErrorMessage(error.message);
         }
-    }
+    };
     const handleChangeForm = () => {
-        navigate("/agree")
-    }
+        navigate("/agree");
+    };
 
     /**
      * 입력 필드의 변경을 처리하는 함수입니다.
@@ -56,13 +57,19 @@ export default function SignInForm() {
     };
 
     return (
-        <div className="mx-auto w-full min-w-96 border px-4 py-8 rounded-lg shadow-md">
-            <form onSubmit={handleSubmit} className="space-y-6 px-10">
-                <div>
-                    <label htmlFor="email" className="block text-sm/6 font-medium text-gray-900">
-                        Email address
-                    </label>
-                    <div className="mt-2">
+        <div className="relative mx-auto w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-2xl backdrop-blur-xl">
+            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-transparent" aria-hidden="true" />
+            <div className="relative px-6 py-8 sm:px-10 sm:py-10">
+                <div className="space-y-2 text-center text-white">
+                    <p className="text-xs font-semibold uppercase tracking-[0.4em] text-indigo-200">Welcome back</p>
+                    <h2 className="text-2xl font-semibold sm:text-3xl">계정으로 로그인하세요</h2>
+                    <p className="text-sm text-slate-200/80">보안을 강화한 싱글 사인온으로 더 빠르고 안전하게 접근할 수 있어요.</p>
+                </div>
+                <form onSubmit={handleSubmit} className="mt-10 space-y-6">
+                    <div className="space-y-2">
+                        <label htmlFor="userId" className="block text-sm font-medium text-slate-100">
+                            Email address
+                        </label>
                         <input
                             id="userId"
                             name="userId"
@@ -70,71 +77,66 @@ export default function SignInForm() {
                             autoComplete="email"
                             value={formState.userId}
                             onChange={handleInputChange("userId")}
-                            className=" block w-[22rem] rounded-md bg-white px-3 py-4 text-base text-gray-900
-                            outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400
-                            focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                            className="block w-full rounded-2xl border border-white/20 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-300/80"
                         />
                     </div>
-                </div>
 
-                <div>
-                    <div className="flex items-center justify-between">
-                        <label htmlFor="password" className="block text-sm/6 font-medium text-gray-900">
-                            Password
-                        </label>
-                        <div className="text-sm">
-                            <Link to="/support" className="font-semibold text-indigo-600 hover:text-indigo-500">
+                    <div className="space-y-2">
+                        <div className="flex items-center justify-between">
+                            <label htmlFor="password" className="block text-sm font-medium text-slate-100">
+                                Password
+                            </label>
+                            <Link to="/support" className="text-xs font-semibold text-indigo-200 transition hover:text-indigo-100">
                                 Forgot password?
                             </Link>
                         </div>
-                    </div>
-                    <div className="mt-2">
                         <input
                             id="password"
                             name="password"
                             type="password"
                             autoComplete="current-password"
                             value={formState.password}
-                            onChange={handleInputChange('password')}
-                            className="block w-full rounded-md bg-white px-3 py-4 text-base text-gray-900 outline outline-1 -outline-offset-1 outline-gray-300 placeholder:text-gray-400 focus:outline focus:outline-2 focus:-outline-offset-2 focus:outline-indigo-600 sm:text-sm/6"
+                            onChange={handleInputChange("password")}
+                            className="block w-full rounded-2xl border border-white/20 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-300/80"
                         />
                     </div>
-                </div>
 
-                <div>
                     <button
                         type="submit"
-                        className="flex w-full justify-center rounded-md bg-indigo-600 px-3 py-4 text-sm/6 font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+                        className="flex w-full justify-center rounded-2xl bg-gradient-to-r from-indigo-500 via-indigo-400 to-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:from-indigo-400 hover:via-indigo-500 hover:to-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200"
                     >
                         Sign in
                     </button>
-                </div>
-                <div>
-                    <LoginErrorMessage
-                        status={errorStatus}
-                        message={errorMessage}
-                        onClose={() => {
-                            setErrorStatus(null);
-                            setErrorMessage(null);
-                        }}
-                    />
-                </div>
-            </form>
 
-            <div className="relative my-8 flex w-full items-center">
-                <div className="flex-1 border-gray-500 border-t-2 border-dotted ml-10"/>
-                <span className="bg-white px-4 font-medium text-gray-500">OR</span>
-                <div className="flex-1 border-gray-500 border-t-2 border-dotted mr-10"/>
+                    <div>
+                        <LoginErrorMessage
+                            status={errorStatus}
+                            message={errorMessage}
+                            onClose={() => {
+                                setErrorStatus(null);
+                                setErrorMessage(null);
+                            }}
+                        />
+                    </div>
+                </form>
+
+                <div className="relative mt-8 flex items-center">
+                    <span className="h-px flex-1 bg-white/10" />
+                    <span className="px-3 text-xs font-medium uppercase tracking-[0.3em] text-slate-200/80">or</span>
+                    <span className="h-px flex-1 bg-white/10" />
+                </div>
+
+                <div className="mt-6">
+                    <GoogleLoginButton />
+                </div>
+
+                <p className="mt-10 text-center text-sm text-slate-200/80">
+                    아직 멤버가 아니신가요?{' '}
+                    <button className="font-semibold text-indigo-200 transition hover:text-indigo-100" onClick={handleChangeForm}>
+                        지금 가입하기
+                    </button>
+                </p>
             </div>
-            <div className="mx-10">
-                <GoogleLoginButton/>
-            </div>
-            <p className="mt-10 text-center text-sm/6 text-gray-500">
-                Not a member yet? {' '}
-                <button className="font-semibold text-indigo-600 hover:text-indigo-500" onClick={handleChangeForm}>
-                    Register Now
-                </button>
-            </p>
         </div>
-    )
+    );
 }

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -1,60 +1,107 @@
 import React, { Fragment } from "react";
 import { Transition } from "@headlessui/react";
 import SignInForm from "features/login/signInForm";
-import {useNavigate} from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import Footer from "../features/footer/footer";
 
 export default function Login() {
     const navigate = useNavigate();
+
     const navigateToHome = () => {
         navigate("/");
-    }
-    return (
-        <div className="p-20 ">
-            <div className="mt-14">
-                <div className="col-span-2 flex justify-center items-center" >
-                    <h2 onClick={navigateToHome} translate="no" className="cursor-pointer select-none text-[clamp(28px,5vw,60px)]
-                    font-extrabold tracking-tight leading-none text-indigo-500 drop-shadow-md mb-12">
-                        GRAVIFOX.
-                    </h2>
-                </div>
-                <div className="flex flex-1 justify-center items-center">
-                    {/* 로그인 폼 */}
-                    <Transition
-                        show
-                        as={Fragment}
-                        enter="transition duration-1000 ease-in-out transform"
-                        enterFrom="translate-x-full opacity-0"
-                        enterTo="translate-x-0 opacity-100"
-                        leave="transition duration-1000 ease-in-out transform"
-                        leaveFrom="translate-x-0 opacity-100"
-                        leaveTo="-translate-x-full opacity-0"
-                        appear={true}
-                    >
-                        <div className="">
-                            <SignInForm />
-                        </div>
-                    </Transition>
+    };
 
-                    {/*/!* 회원가입 폼 *!/*/}
-                    {/*<Transition*/}
-                    {/*    show={showSignUp}*/}
-                    {/*    as={Fragment}*/}
-                    {/*    enter="transition duration-1000 ease-in-out transform"*/}
-                    {/*    enterFrom="-translate-x-full opacity-0"*/}
-                    {/*    enterTo="translate-x-0 opacity-100"*/}
-                    {/*    leave="transition duration-1000 ease-in-out transform"*/}
-                    {/*    leaveFrom="translate-x-0 opacity-100"*/}
-                    {/*    leaveTo="translate-x-full opacity-0"*/}
-                    {/*    appear={true}*/}
-                    {/*>*/}
-                    {/*    <div className="absolute w-full">*/}
-                    {/*        <SignUpForm changeForm={() => switchToSignIn()} />*/}
-                    {/*    </div>*/}
-                    {/*</Transition>*/}
+    const navigateToRegister = () => {
+        navigate("/agree");
+    };
+
+    return (
+        <div className="relative min-h-screen overflow-hidden bg-slate-950 text-white">
+            <div className="pointer-events-none absolute inset-0">
+                <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950" />
+                <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/30 blur-3xl" />
+                <div className="absolute -bottom-24 left-10 h-64 w-64 rounded-full bg-sky-500/10 blur-3xl" />
+                <div className="absolute bottom-0 right-0 h-[28rem] w-[28rem] translate-x-1/3 translate-y-1/3 rounded-full bg-purple-500/20 blur-3xl" />
+            </div>
+            <div className="relative z-10 flex min-h-screen flex-col">
+                <header className="flex flex-col gap-6 px-6 pt-10 sm:px-10 lg:flex-row lg:items-center lg:justify-between lg:px-16">
+                    <h1
+                        onClick={navigateToHome}
+                        translate="no"
+                        className="cursor-pointer text-center text-3xl font-black tracking-[0.4em] text-white drop-shadow-lg sm:text-4xl lg:text-left"
+                    >
+                        GRAVIFOX.
+                    </h1>
+                    <div className="flex flex-1 flex-col items-center justify-end gap-2 text-center text-sm text-slate-200/80 lg:flex-none lg:flex-row lg:justify-end lg:text-right">
+                        <span className="font-medium">처음 방문하셨나요?</span>
+                        <button
+                            type="button"
+                            onClick={navigateToRegister}
+                            className="rounded-full border border-white/20 bg-white/5 px-5 py-2 font-semibold text-white shadow-lg shadow-indigo-900/20 transition hover:border-white/40 hover:bg-white/10"
+                        >
+                            지금 바로 가입하기
+                        </button>
+                    </div>
+                </header>
+
+                <main className="flex flex-1 flex-col justify-center gap-16 px-6 pb-16 pt-12 sm:px-10 lg:flex-row lg:items-center lg:justify-between lg:px-16 lg:pt-10">
+                    <section className="mx-auto max-w-2xl text-center lg:mx-0 lg:max-w-xl lg:text-left">
+                        <p className="text-xs font-semibold uppercase tracking-[0.5em] text-indigo-200">Secure Console</p>
+                        <h2 className="mt-6 text-3xl font-semibold leading-tight text-white sm:text-4xl lg:text-5xl">
+                            통합 인텔리전스로 업무를 더 우아하게 완성하세요
+                        </h2>
+                        <p className="mt-6 text-base leading-relaxed text-slate-200/80">
+                            Gravifox는 데이터를 읽고 해석하며, 팀과 함께 협업할 수 있는 분석 경험을 제공합니다. 로그인하고 맞춤화된 인사이트와 워크플로를 바로 이어가 보세요.
+                        </p>
+                        <ul className="mt-10 grid gap-6 text-left sm:grid-cols-2 lg:grid-cols-1">
+                            <li className="flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                                <span className="mt-1 flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500/20 text-indigo-200">
+                                    <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="m4.5 12.75 6 6 9-13.5" />
+                                    </svg>
+                                </span>
+                                <div>
+                                    <p className="text-base font-semibold text-white">실시간 보안 모니터링</p>
+                                    <p className="mt-2 text-sm text-slate-200/80">중요 이벤트와 알림을 한눈에 확인하고, 팀원과 즉시 공유하세요.</p>
+                                </div>
+                            </li>
+                            <li className="flex items-start gap-4 rounded-2xl border border-white/10 bg-white/5 p-4 backdrop-blur">
+                                <span className="mt-1 flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500/20 text-indigo-200">
+                                    <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24" aria-hidden="true">
+                                        <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 12h16.5m-12-6h7.5m-9 12h10.5" />
+                                    </svg>
+                                </span>
+                                <div>
+                                    <p className="text-base font-semibold text-white">맞춤형 분석 보드</p>
+                                    <p className="mt-2 text-sm text-slate-200/80">역할에 맞게 구성된 대시보드로 필요한 인사이트를 정확히 얻을 수 있어요.</p>
+                                </div>
+                            </li>
+                        </ul>
+                    </section>
+
+                    <section className="mx-auto w-full max-w-md lg:max-w-lg">
+                        <Transition
+                            show
+                            as={Fragment}
+                            enter="transition duration-1000 ease-in-out transform"
+                            enterFrom="translate-y-10 opacity-0 lg:translate-x-16"
+                            enterTo="translate-y-0 opacity-100 lg:translate-x-0"
+                            leave="transition duration-1000 ease-in-out transform"
+                            leaveFrom="translate-y-0 opacity-100"
+                            leaveTo="translate-y-10 opacity-0 lg:-translate-x-16"
+                            appear={true}
+                        >
+                            <div>
+                                <SignInForm />
+                            </div>
+                        </Transition>
+                    </section>
+                </main>
+
+                <div className="mt-auto">
+                    <Footer transparent />
                 </div>
             </div>
-            <Footer />
         </div>
     );
 }


### PR DESCRIPTION
## 변경 목적
- 로그인 페이지의 시각적 완성도를 높이고 다양한 화면 크기에서 자연스럽게 동작하도록 만들었어요.

## 주요 변경점
- `src/pages/login.js`에서 히어로 섹션과 애니메이션이 포함된 전체 레이아웃을 재구성하고 모바일 대응을 강화했어요.
- `src/features/login/signInForm.js`에서 폼 컨테이너를 유리모피즘 스타일로 꾸미고 입력 필드, 버튼, 부가 텍스트를 고급스럽게 다듬었어요.

## 테스트 결과 요약
- `npm run build` *(실패: 기존에 누락된 `output.css` 의존성 때문에 빌드가 중단됐어요)*

## 보안·성능 고려사항
- 신규 UI는 클라이언트 렌더링만 변경하며 인증 로직과 네트워크 통신에는 영향을 주지 않았어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e1f97e61448323ae104fdc80e69a2a