### PR TITLE
[feat] 메인 반응형 레이아웃을 다듬었어요

### DIFF
--- a/src/features/main/anchorNav.js
+++ b/src/features/main/anchorNav.js
@@ -108,11 +108,12 @@ export default function AnchorNav() {
     <nav
       ref={navRef}
       id="anchor-nav"
-      className="sticky z-20 w-full border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70"
+      className="hidden md:block sticky z-20 w-full border-b border-slate-200/70 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/70"
       style={{ top: headerOffset }}
+      aria-label={t('anchor.label', 'Main section navigation')}
     >
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <ul className="flex flex-nowrap items-center gap-2 overflow-x-auto py-3 text-sm no-scrollbar">
+      <div className="mx-auto max-w-6xl px-6 lg:px-8">
+        <ul className="flex flex-nowrap items-center gap-2 overflow-x-auto py-3 text-sm no-scrollbar md:justify-center">
           {items.map((it) => {
             const Icon = iconMap[it.id] || PlayIcon;
             const isActive = active === it.id;

--- a/src/features/main/howItWorks.js
+++ b/src/features/main/howItWorks.js
@@ -42,11 +42,11 @@ export default function HowItWorks() {
           </p>
         </div>
 
-        <div className="mt-12 grid gap-6 lg:grid-cols-3">
+        <div className="mt-12 flex snap-x snap-mandatory gap-4 overflow-x-auto pb-6 sm:gap-6 sm:pb-8 lg:grid lg:grid-cols-3 lg:gap-6 lg:overflow-visible lg:pb-0">
           {steps.map(({ key, icon: Icon, annotation, glideKey }, index) => (
             <article
               key={key}
-              className="group relative overflow-hidden rounded-3xl border border-indigo-100 bg-white/80 px-6 py-8 shadow-lg shadow-indigo-100/40 backdrop-blur transition hover:-translate-y-2 hover:shadow-2xl"
+              className="group relative min-w-[240px] snap-start overflow-hidden rounded-3xl border border-indigo-100 bg-white/80 px-6 py-8 shadow-lg shadow-indigo-100/40 backdrop-blur transition hover:-translate-y-2 hover:shadow-2xl lg:min-w-0"
             >
               <div className="absolute inset-0 bg-gradient-to-br from-white via-indigo-50/70 to-white" aria-hidden="true" />
               <div className="absolute -left-6 top-10 h-20 w-20 rounded-full bg-indigo-200/40 blur-3xl" aria-hidden="true" />

--- a/src/features/main/pageSection.js
+++ b/src/features/main/pageSection.js
@@ -1,8 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { ArrowOutward, HeadsetMic, CheckCircle } from '@mui/icons-material';
-import { Bug, Lightbulb, MessageSquare } from "lucide-react";
-import { Sparkles } from "lucide-react";
-import { Upload, ScanSearch, CheckCircle2 } from "lucide-react";
+import { ArrowOutward, CheckCircle } from '@mui/icons-material';
+import { MessageSquare, Sparkles, Upload, ScanSearch, CheckCircle2 } from "lucide-react";
 
 export default function PageSection() {
     const { t, i18n } = useTranslation('home');
@@ -50,9 +48,10 @@ export default function PageSection() {
                 className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.35),_transparent_65%)]"
                 aria-hidden="true"
             />
-            <div className="relative mx-auto max-w-6xl px-6 py-24 sm:py-28 lg:py-32">
+            <div className="relative mx-auto max-w-6xl px-6 py-20 sm:py-24 lg:py-32">
                 <div className="mx-auto max-w-5xl">
-                    <div className="
+                    <div className="flex justify-center sm:justify-start">
+                        <div className="
     inline-flex items-center gap-1.5 sm:gap-2
     rounded-full border border-white/20 bg-white/10
     px-2.5 py-0.5 sm:px-4 sm:py-1 md:px-5 md:py-1.5
@@ -60,23 +59,22 @@ export default function PageSection() {
     tracking-[0.08em] sm:tracking-[0.1em]
     text-indigo-200 shadow-md sm:shadow-lg shadow-indigo-500/20
   ">
-                        {t('hero.ribbon')}
+                            {t('hero.ribbon')}
+                        </div>
                     </div>
                 </div>
 
 
-                <div className="mt-4 grid gap-12 lg:grid-cols-[1.25fr_0.9fr] lg:items-center">
+                <div className="mt-6 grid gap-12 lg:grid-cols-[1.25fr_0.9fr] lg:items-center">
                     <div className="space-y-8 text-indigo-50">
-                        <div className="space-y-5">
-                            <h1 className="text-[22px] sm:text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight leading-tight">
+                        <div className="space-y-5 text-center sm:text-left">
+                            <h1 className="text-[26px] sm:text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight leading-tight">
                                 {t('hero.headline')}
                             </h1>
 
-                            <p className="flex items-start gap-2 text-[13px] sm:text-base md:text-lg lg:text-xl text-indigo-100/90 max-w-3xl leading-snug sm:leading-normal md:leading-relaxed bg-indigo-300/10 ring-1 ring-inset ring-white/10 rounded-xl px-3 py-2">
-                                <Sparkles className="mt-0.5 h-4 w-4 opacity-80 flex-none" />
-                                <span>
-    {t('hero.subtitle')}
-  </span>
+                            <p className="mx-auto flex max-w-3xl items-start gap-2 rounded-xl bg-indigo-300/10 px-3 py-2 text-[13px] leading-snug text-indigo-100/90 ring-1 ring-inset ring-white/10 sm:mx-0 sm:text-base sm:leading-normal md:text-lg md:leading-relaxed lg:text-xl">
+                                <Sparkles className="mt-0.5 h-4 w-4 flex-none opacity-80" />
+                                <span>{t('hero.subtitle')}</span>
                             </p>
 
 
@@ -85,7 +83,7 @@ export default function PageSection() {
 
                         </div>
 
-                        <div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+                        <div className="flex flex-col items-stretch gap-4 sm:flex-row sm:items-center sm:justify-center lg:justify-start">
                             <a
                                 href={`/${lng}/analyze`}
                                 className="
@@ -124,9 +122,7 @@ export default function PageSection() {
                                 className="
     inline-flex items-center gap-2
     text-sm font-semibold
-    text-indigo-300 hover:text-indigo-100
-    transition-all duration-200
-    hover:translate-x-0.5
+    text-indigo-300 transition-all duration-200 hover:translate-x-0.5 hover:text-indigo-100
   "
                             >
                                 <MessageSquare className="h-4 w-4 text-indigo-300 group-hover:text-indigo-100 transition-colors duration-200" />
@@ -135,14 +131,14 @@ export default function PageSection() {
 
                         </div>
 
-                        <div className="grid gap-4 sm:grid-cols-3">
+                        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 sm:gap-4">
                             {metrics.map((metric, i) => (
                                 <div
                                     key={metric.value}
                                     className="
             group relative overflow-hidden
             rounded-2xl border border-white/10 bg-white/[0.06]
-            px-5 py-5
+            px-4 py-4 sm:px-5 sm:py-5
             text-indigo-100/90
             backdrop-blur-sm
             transition-all duration-300
@@ -166,22 +162,22 @@ export default function PageSection() {
                             ))}
                         </div>
 
-                        {/*<ul className="mt-6 space-y-3 text-sm text-indigo-100/80">*/}
-                        {/*    {bulletPoints.map((line, idx) => (*/}
-                        {/*        <li key={idx} className="flex items-start gap-2">*/}
-                        {/*            <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" />*/}
-                        {/*            <span>{line}</span>*/}
-                        {/*        </li>*/}
-                        {/*    ))}*/}
-                        {/*</ul>*/}
+                        <ul className="mt-6 grid gap-3 text-left text-sm text-indigo-100/80 sm:hidden">
+                            {bulletPoints.map((line, idx) => (
+                                <li key={idx} className="flex items-start gap-2 rounded-2xl bg-white/5 px-3 py-2">
+                                    <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" />
+                                    <span>{line}</span>
+                                </li>
+                            ))}
+                        </ul>
                     </div>
 
                     {quickGuides.length > 0 && (
-                        <div className="relative flex flex-col gap-4">
+                        <div className="relative -mx-1 flex snap-x snap-mandatory gap-3 overflow-x-auto pb-4 sm:mx-0 sm:grid sm:grid-cols-1 sm:gap-4 sm:overflow-visible sm:pb-0 lg:gap-6">
                             {quickGuides.map((card, idx) => (
                                 <article
                                     key={`${card.title}-${idx}`}
-                                    className="relative overflow-hidden rounded-3xl border border-white/15 bg-white/10 p-6 text-indigo-100 shadow-[0_30px_60px_-35px_rgba(15,23,42,0.95)] backdrop-blur"
+                                    className="relative min-w-[260px] snap-start overflow-hidden rounded-3xl border border-white/15 bg-white/10 p-6 text-indigo-100 shadow-[0_30px_60px_-35px_rgba(15,23,42,0.95)] backdrop-blur sm:min-w-0"
                                 >
                                     <div className="absolute inset-0 bg-gradient-to-br from-white/18 via-indigo-400/10 to-white/5" aria-hidden="true" />
                                     <div className="relative flex flex-col gap-3">


### PR DESCRIPTION
## 변경 목적
- 메인 페이지를 모바일에서도 자연스럽게 사용할 수 있도록 앵커 내비게이션과 히어로 섹션 레이아웃을 다듬었어요.

## 주요 변경점
- 모바일 구간에서는 앵커 내비게이션을 숨기고 데스크톱에서는 중앙 정렬된 유리질감 스타일로 재배치했어요.
- 히어로 영역을 중앙 정렬, 2열 지표 카드, 모바일 전용 주요 포인트 리스트, 가로 스크롤 카드 등을 추가해 반응형 레이아웃을 강화했어요.
- "How it works" 단계 카드도 모바일에서 스와이프 가능한 스냅 레이아웃으로 바꿨어요.

## 테스트 결과 요약
- `npm test -- --watch=false` 명령을 실행해 변경 사항이 기존 테스트를 통과하는지 확인했어요.

## 보안·성능 고려사항
- 스타일과 레이아웃 변경으로 보안이나 성능에 영향을 주는 변경은 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e20b5188488323be1e08c15e43ed92