### PR TITLE
[fix, style] 로그인 화면 네비게이션과 디자인을 정리했어요

### DIFF
--- a/src/features/login/signInForm.js
+++ b/src/features/login/signInForm.js
@@ -57,20 +57,17 @@ export default function SignInForm() {
     };
 
     return (
-        <div className="relative mx-auto w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-2xl backdrop-blur-xl">
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-transparent" aria-hidden="true" />
-            <div className="relative px-6 py-8 sm:px-10 sm:py-10">
-                <div className="space-y-2 text-center text-white">
-                    <p className="text-xs font-semibold uppercase tracking-[0.4em] text-indigo-200">Welcome back</p>
-                    <h2 className="text-2xl font-semibold sm:text-3xl">계정으로 로그인하세요</h2>
-                    <p className="text-sm text-slate-200/80">보안을 강화한 싱글 사인온으로 더 빠르고 안전하게 접근할 수 있어요.</p>
-                </div>
-                <form onSubmit={handleSubmit} className="mt-10 space-y-6">
-                    <div className="space-y-2">
-                        <label htmlFor="userId" className="block text-sm font-medium text-slate-100">
-                            Email address
-                        </label>
-                        <input
+        <div className="mx-auto w-full rounded-3xl border border-white/12 bg-slate-950/80 px-6 py-8 shadow-[0_24px_64px_-32px_rgba(15,23,42,0.8)] backdrop-blur-xl sm:px-10 sm:py-10">
+            <div className="text-center text-white">
+                <h2 className="text-2xl font-semibold sm:text-3xl">로그인</h2>
+                <p className="mt-2 text-[11px] font-semibold uppercase tracking-[0.35em] text-indigo-200/70">Gravifox secure</p>
+            </div>
+            <form onSubmit={handleSubmit} className="mt-10 space-y-6">
+                <div className="space-y-2">
+                    <label htmlFor="userId" className="block text-sm font-medium text-slate-100">
+                        Email address
+                    </label>
+                    <input
                             id="userId"
                             name="userId"
                             type="text"
@@ -136,7 +133,6 @@ export default function SignInForm() {
                         지금 가입하기
                     </button>
                 </p>
-            </div>
         </div>
     );
 }

--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -2,7 +2,7 @@ import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'reac
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { PopoverGroup, Transition } from '@headlessui/react';
-import { Bars3Icon, ChevronRightIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from 'providers/authProvider';
@@ -378,41 +378,6 @@ const Navigation = () => {
                                                 <XMarkIcon aria-hidden="true" className="size-6" />
                                             </button>
                                         </div>
-
-                                        <nav className="mt-5 space-y-2">
-                                            {navItems.map((item, idx) => {
-                                                const isActive = activeItemKey === item.key;
-                                                const linkClasses = `group flex items-center justify-between gap-4 rounded-2xl px-5 py-3.5 text-base font-semibold transition ${
-                                                    isActive
-                                                        ? 'bg-indigo-50/95 text-indigo-600 shadow-[0_18px_36px_-24px_rgba(79,70,229,0.5)] ring-1 ring-inset ring-indigo-100'
-                                                        : 'text-slate-700 hover:bg-slate-50/95 hover:text-slate-900 hover:ring-1 hover:ring-inset hover:ring-slate-200'
-                                                }`;
-                                                const itemAnimBase = reducedMotion
-                                                    ? ''
-                                                    : 'transform-gpu transition-all duration-[900ms] ease-[cubic-bezier(0.22,1,0.36,1)]';
-                                                const label = t(item.labelKey);
-                                                return (
-                                                    <Link
-                                                        key={item.key}
-                                                        to={buildLinkTarget(item)}
-                                                        onClick={() => setMobileMenuOpen(false)}
-                                                        className={`${linkClasses} ${mobileMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
-                                                        style={{ transitionDelay: reducedMotion ? undefined : `${Math.min(idx * 120, 600)}ms` }}
-                                                        data-open={mobileMenuOpen ? '' : undefined}
-                                                    >
-                                                        <span className={`${itemAnimBase} whitespace-normal break-words text-left`}>{label}</span>
-                                                        <span className={`flex items-center gap-2 text-sm font-medium ${itemAnimBase}`}>
-                                                            {isActive && (
-                                                                <span className="inline-flex items-center rounded-full bg-indigo-100/90 px-2 py-0.5 text-[11px] font-medium text-indigo-600 shadow-sm">
-                                                                    {t('navigation.current')}
-                                                                </span>
-                                                            )}
-                                                            <ChevronRightIcon aria-hidden="true" className="size-4 text-slate-300 transition-colors group-hover:text-indigo-300" />
-                                                        </span>
-                                                    </Link>
-                                                );
-                                            })}
-                                        </nav>
 
                                         <div className="mt-6">
                                             <Link

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -7,30 +7,29 @@ export default function Login() {
     return (
         <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 text-white">
             <div className="pointer-events-none absolute inset-0">
-                <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950" />
-                <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/30 blur-3xl" />
-                <div className="absolute bottom-10 left-4 h-48 w-48 rounded-full bg-sky-500/10 blur-3xl" />
-                <div className="absolute bottom-0 right-0 h-80 w-80 translate-x-1/3 translate-y-1/3 rounded-full bg-purple-500/20 blur-3xl" />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(88,111,255,0.16),transparent_65%),radial-gradient(circle_at_bottom,rgba(30,41,59,0.9),rgba(15,23,42,1))]" />
+                <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/25 blur-3xl" />
+                <div className="absolute bottom-16 left-10 h-56 w-56 rounded-full bg-sky-500/10 blur-3xl" />
             </div>
 
             <div className="relative z-10 flex min-h-screen flex-col">
                 <Navigation />
 
-                <main className="flex flex-1 flex-col items-center px-6 pb-16 pt-12 sm:px-8 lg:px-12">
-                    <section className="w-full max-w-xl space-y-6 text-center lg:space-y-8">
-                        <div className="space-y-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.45em] text-indigo-200">Log in</p>
-                            <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
-                                계정에 접속해 작업을 이어가세요
-                            </h1>
-                            <p className="text-sm leading-relaxed text-slate-200/80 sm:text-base">
-                                Gravifox 보안 콘솔에 로그인하고 팀의 프로젝트와 데이터를 한곳에서 관리하세요.
-                            </p>
-                        </div>
+                <main className="flex flex-1 flex-col items-center px-6 pb-20 pt-28 sm:px-8 sm:pt-32 lg:px-12 lg:pt-40">
+                    <section className="w-full max-w-xl text-center">
+                        <p className="text-[11px] font-semibold uppercase tracking-[0.5em] text-indigo-200/80">Sign in</p>
+                        <h1 className="mt-4 text-3xl font-semibold leading-tight text-white sm:text-4xl">
+                            미래형 Gravifox 콘솔에 접속하세요
+                        </h1>
+                        <p className="mt-3 text-sm text-slate-200/80">
+                            필요한 정보만 입력하고 바로 업무를 이어가세요.
+                        </p>
                     </section>
 
                     <section className="mt-10 w-full max-w-md sm:mt-12">
-                        <SignInForm />
+                        <div className="rounded-[28px] border border-white/10 bg-slate-950/60 p-2 shadow-[0_18px_48px_-24px_rgba(15,23,42,0.7)] backdrop-blur-2xl">
+                            <SignInForm />
+                        </div>
                     </section>
                 </main>
 


### PR DESCRIPTION
## 변경 목적
- 모바일에서 햄버거 메뉴를 열었을 때 앵커 내비게이션이 과하게 노출되는 문제를 정리했어요.
- 로그인 화면 본문이 고정 내비게이션에 가려지고 시각적 요소가 번잡하던 부분을 깔끔하게 다듬었어요.

## 주요 변경점
- 모바일 메뉴에서 앵커 링크 목록을 제거해 필요한 행동만 남겨두었어요.
- 로그인 페이지 배경과 여백을 재구성하고, 카드 스타일을 조정해 고급스럽고 미래지향적인 톤으로 정리했어요.
- 로그인 폼 헤더 텍스트를 최소화하고 배경을 정리해 간결한 인상을 주도록 했어요.

## 테스트 결과 요약
- `npm test -- --watchAll=false` 명령을 실행했지만 `react-router-dom` 모듈을 찾지 못해 실패했어요.

## 보안·성능 고려사항
- 보안 및 성능에 영향을 주는 변경은 없어요.

## 관련 이슈 번호
- -

------
https://chatgpt.com/codex/tasks/task_e_68e211e0a9dc8323a06ef8da1b38bc3f