### PR TITLE
[fix] 모바일 로그인 화면과 내비게이션을 다듬었어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -2,7 +2,7 @@ import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'reac
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { PopoverGroup, Transition } from '@headlessui/react';
-import { Bars3Icon, ChevronRightIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from 'providers/authProvider';
@@ -379,40 +379,14 @@ const Navigation = () => {
                                             </button>
                                         </div>
 
-                                        <nav className="mt-5 space-y-2">
-                                            {navItems.map((item, idx) => {
-                                                const isActive = activeItemKey === item.key;
-                                                const linkClasses = `group flex items-center justify-between gap-4 rounded-2xl px-5 py-3.5 text-base font-semibold transition ${
-                                                    isActive
-                                                        ? 'bg-indigo-50/95 text-indigo-600 shadow-[0_18px_36px_-24px_rgba(79,70,229,0.5)] ring-1 ring-inset ring-indigo-100'
-                                                        : 'text-slate-700 hover:bg-slate-50/95 hover:text-slate-900 hover:ring-1 hover:ring-inset hover:ring-slate-200'
-                                                }`;
-                                                const itemAnimBase = reducedMotion
-                                                    ? ''
-                                                    : 'transform-gpu transition-all duration-[900ms] ease-[cubic-bezier(0.22,1,0.36,1)]';
-                                                const label = t(item.labelKey);
-                                                return (
-                                                    <Link
-                                                        key={item.key}
-                                                        to={buildLinkTarget(item)}
-                                                        onClick={() => setMobileMenuOpen(false)}
-                                                        className={`${linkClasses} ${mobileMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
-                                                        style={{ transitionDelay: reducedMotion ? undefined : `${Math.min(idx * 120, 600)}ms` }}
-                                                        data-open={mobileMenuOpen ? '' : undefined}
-                                                    >
-                                                        <span className={`${itemAnimBase} whitespace-normal break-words text-left`}>{label}</span>
-                                                        <span className={`flex items-center gap-2 text-sm font-medium ${itemAnimBase}`}>
-                                                            {isActive && (
-                                                                <span className="inline-flex items-center rounded-full bg-indigo-100/90 px-2 py-0.5 text-[11px] font-medium text-indigo-600 shadow-sm">
-                                                                    {t('navigation.current')}
-                                                                </span>
-                                                            )}
-                                                            <ChevronRightIcon aria-hidden="true" className="size-4 text-slate-300 transition-colors group-hover:text-indigo-300" />
-                                                        </span>
-                                                    </Link>
-                                                );
-                                            })}
-                                        </nav>
+                                        <div className="mt-5 rounded-2xl border border-slate-200/80 bg-white/70 px-5 py-4 text-left shadow-[inset_0_1px_0_rgba(255,255,255,0.4)]">
+                                            <p className="text-sm font-semibold text-slate-900">{t('navigation.focusTitle', { defaultValue: '필수 작업에 집중하세요' })}</p>
+                                            <p className="mt-1 text-xs leading-relaxed text-slate-500">
+                                                {t('navigation.focusDescription', {
+                                                    defaultValue: '모바일에서는 주요 내비게이션을 숨기고 로그인과 지원에 집중했어요.',
+                                                })}
+                                            </p>
+                                        </div>
 
                                         <div className="mt-6">
                                             <Link

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -7,30 +7,30 @@ export default function Login() {
     return (
         <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 text-white">
             <div className="pointer-events-none absolute inset-0">
-                <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950" />
-                <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/30 blur-3xl" />
-                <div className="absolute bottom-10 left-4 h-48 w-48 rounded-full bg-sky-500/10 blur-3xl" />
-                <div className="absolute bottom-0 right-0 h-80 w-80 translate-x-1/3 translate-y-1/3 rounded-full bg-purple-500/20 blur-3xl" />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(99,102,241,0.28),_transparent_55%),_radial-gradient(circle_at_bottom,_rgba(15,23,42,0.9),_rgba(2,6,23,1))]" />
+                <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 -translate-y-2/3 rounded-full bg-indigo-500/20 blur-3xl" />
+                <div className="absolute right-[12%] top-1/4 h-56 w-56 -translate-y-1/3 rounded-full bg-purple-500/20 blur-3xl" />
             </div>
 
             <div className="relative z-10 flex min-h-screen flex-col">
                 <Navigation />
 
-                <main className="flex flex-1 flex-col items-center px-6 pb-16 pt-12 sm:px-8 lg:px-12">
-                    <section className="w-full max-w-xl space-y-6 text-center lg:space-y-8">
-                        <div className="space-y-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.45em] text-indigo-200">Log in</p>
+                <main className="flex flex-1 flex-col items-center px-6 pb-16 pt-28 sm:px-8 lg:px-12">
+                    <section className="w-full max-w-xl text-center">
+                        <div className="space-y-4">
                             <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
-                                계정에 접속해 작업을 이어가세요
+                                미래형 보안 허브에 로그인하세요
                             </h1>
-                            <p className="text-sm leading-relaxed text-slate-200/80 sm:text-base">
-                                Gravifox 보안 콘솔에 로그인하고 팀의 프로젝트와 데이터를 한곳에서 관리하세요.
+                            <p className="mx-auto max-w-md text-sm leading-relaxed text-slate-200/80 sm:text-base">
+                                꼭 필요한 정보만 담은 간결한 화면에서 팀의 자산을 안전하게 이어가요.
                             </p>
                         </div>
                     </section>
 
-                    <section className="mt-10 w-full max-w-md sm:mt-12">
-                        <SignInForm />
+                    <section className="mt-12 w-full max-w-md">
+                        <div className="rounded-3xl border border-white/10 bg-slate-900/70 p-8 shadow-[0_24px_60px_-30px_rgba(79,70,229,0.55)] backdrop-blur">
+                            <SignInForm />
+                        </div>
                     </section>
                 </main>
 


### PR DESCRIPTION
## 변경 목적
- 모바일에서 앵커 내비게이션을 숨기고 로그인 화면 가독성을 높이기 위함이에요.

## 주요 변경점
- 로그인 페이지 배경과 카드 레이아웃을 정리해서 고급스럽고 미니멀한 톤으로 바꿨어요.
- 내비게이션 모바일 패널에서 앵커 목록 대신 안내 블록만 노출하도록 수정했어요.

## 테스트 결과 요약
- `npm test -- --watchAll=false` 명령을 실행했지만 `react-router-dom` 모듈을 찾지 못해 실패했어요.

## 보안·성능 고려사항
- 새로운 의존성을 추가하지 않았고 렌더링 비용에 큰 변화가 없어요.

## 관련 이슈 번호
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68e211e0a9dc8323a06ef8da1b38bc3f