### PR TITLE
[fix, style] 로그인 화면이 가려지는 문제를 해결하고 디자인을 정리했어요

### DIFF
--- a/src/features/login/signInForm.js
+++ b/src/features/login/signInForm.js
@@ -57,15 +57,14 @@ export default function SignInForm() {
     };
 
     return (
-        <div className="relative mx-auto w-full max-w-md overflow-hidden rounded-3xl border border-white/10 bg-white/5 shadow-2xl backdrop-blur-xl">
-            <div className="absolute inset-0 bg-gradient-to-br from-white/10 via-transparent to-transparent" aria-hidden="true" />
+        <div className="relative mx-auto w-full max-w-md overflow-hidden rounded-[28px] border border-white/15 bg-white/8 shadow-[0_24px_60px_-28px_rgba(15,23,42,0.85)] backdrop-blur-2xl">
+            <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(148,163,255,0.18),transparent_45%),linear-gradient(225deg,rgba(56,189,248,0.12),transparent_55%)]" aria-hidden="true" />
             <div className="relative px-6 py-8 sm:px-10 sm:py-10">
-                <div className="space-y-2 text-center text-white">
-                    <p className="text-xs font-semibold uppercase tracking-[0.4em] text-indigo-200">Welcome back</p>
-                    <h2 className="text-2xl font-semibold sm:text-3xl">계정으로 로그인하세요</h2>
-                    <p className="text-sm text-slate-200/80">보안을 강화한 싱글 사인온으로 더 빠르고 안전하게 접근할 수 있어요.</p>
+                <div className="space-y-3 text-center text-white">
+                    <h2 className="text-2xl font-semibold sm:text-3xl">계정으로 로그인</h2>
+                    <p className="text-sm text-slate-200/80">보안 토큰을 입력하고 즉시 콘솔을 시작하세요.</p>
                 </div>
-                <form onSubmit={handleSubmit} className="mt-10 space-y-6">
+                <form onSubmit={handleSubmit} className="mt-8 space-y-6">
                     <div className="space-y-2">
                         <label htmlFor="userId" className="block text-sm font-medium text-slate-100">
                             Email address
@@ -77,7 +76,7 @@ export default function SignInForm() {
                             autoComplete="email"
                             value={formState.userId}
                             onChange={handleInputChange("userId")}
-                            className="block w-full rounded-2xl border border-white/20 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-300/80"
+                            className="block w-full rounded-2xl border border-white/30 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-sky-300 focus:ring-2 focus:ring-sky-200"
                         />
                     </div>
 
@@ -97,13 +96,13 @@ export default function SignInForm() {
                             autoComplete="current-password"
                             value={formState.password}
                             onChange={handleInputChange("password")}
-                            className="block w-full rounded-2xl border border-white/20 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-300/80"
+                            className="block w-full rounded-2xl border border-white/30 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-sky-300 focus:ring-2 focus:ring-sky-200"
                         />
                     </div>
 
                     <button
                         type="submit"
-                        className="flex w-full justify-center rounded-2xl bg-gradient-to-r from-indigo-500 via-indigo-400 to-indigo-600 px-4 py-3 text-sm font-semibold text-white shadow-lg shadow-indigo-900/40 transition hover:from-indigo-400 hover:via-indigo-500 hover:to-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-200"
+                        className="flex w-full justify-center rounded-2xl bg-gradient-to-r from-indigo-400 via-sky-500 to-emerald-400 px-4 py-3 text-sm font-semibold text-white shadow-[0_18px_42px_-20px_rgba(79,70,229,0.55)] transition hover:from-indigo-300 hover:via-sky-400 hover:to-emerald-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200"
                     >
                         Sign in
                     </button>
@@ -122,7 +121,7 @@ export default function SignInForm() {
 
                 <div className="relative mt-8 flex items-center">
                     <span className="h-px flex-1 bg-white/10" />
-                    <span className="px-3 text-xs font-medium uppercase tracking-[0.3em] text-slate-200/80">or</span>
+                    <span className="px-3 text-xs font-semibold tracking-[0.25em] text-slate-200/70">OR</span>
                     <span className="h-px flex-1 bg-white/10" />
                 </div>
 
@@ -130,10 +129,10 @@ export default function SignInForm() {
                     <GoogleLoginButton />
                 </div>
 
-                <p className="mt-10 text-center text-sm text-slate-200/80">
+                <p className="mt-8 text-center text-sm text-slate-200/80">
                     아직 멤버가 아니신가요?{' '}
                     <button className="font-semibold text-indigo-200 transition hover:text-indigo-100" onClick={handleChangeForm}>
-                        지금 가입하기
+                        가입하기
                     </button>
                 </p>
             </div>

--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -2,7 +2,7 @@ import React, { Fragment, useCallback, useEffect, useMemo, useState } from 'reac
 import { createPortal } from 'react-dom';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { PopoverGroup, Transition } from '@headlessui/react';
-import { Bars3Icon, ChevronRightIcon, XMarkIcon } from '@heroicons/react/24/outline';
+import { Bars3Icon, XMarkIcon } from '@heroicons/react/24/outline';
 import { useTranslation } from 'react-i18next';
 
 import { useAuth } from 'providers/authProvider';
@@ -379,40 +379,9 @@ const Navigation = () => {
                                             </button>
                                         </div>
 
-                                        <nav className="mt-5 space-y-2">
-                                            {navItems.map((item, idx) => {
-                                                const isActive = activeItemKey === item.key;
-                                                const linkClasses = `group flex items-center justify-between gap-4 rounded-2xl px-5 py-3.5 text-base font-semibold transition ${
-                                                    isActive
-                                                        ? 'bg-indigo-50/95 text-indigo-600 shadow-[0_18px_36px_-24px_rgba(79,70,229,0.5)] ring-1 ring-inset ring-indigo-100'
-                                                        : 'text-slate-700 hover:bg-slate-50/95 hover:text-slate-900 hover:ring-1 hover:ring-inset hover:ring-slate-200'
-                                                }`;
-                                                const itemAnimBase = reducedMotion
-                                                    ? ''
-                                                    : 'transform-gpu transition-all duration-[900ms] ease-[cubic-bezier(0.22,1,0.36,1)]';
-                                                const label = t(item.labelKey);
-                                                return (
-                                                    <Link
-                                                        key={item.key}
-                                                        to={buildLinkTarget(item)}
-                                                        onClick={() => setMobileMenuOpen(false)}
-                                                        className={`${linkClasses} ${mobileMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'}`}
-                                                        style={{ transitionDelay: reducedMotion ? undefined : `${Math.min(idx * 120, 600)}ms` }}
-                                                        data-open={mobileMenuOpen ? '' : undefined}
-                                                    >
-                                                        <span className={`${itemAnimBase} whitespace-normal break-words text-left`}>{label}</span>
-                                                        <span className={`flex items-center gap-2 text-sm font-medium ${itemAnimBase}`}>
-                                                            {isActive && (
-                                                                <span className="inline-flex items-center rounded-full bg-indigo-100/90 px-2 py-0.5 text-[11px] font-medium text-indigo-600 shadow-sm">
-                                                                    {t('navigation.current')}
-                                                                </span>
-                                                            )}
-                                                            <ChevronRightIcon aria-hidden="true" className="size-4 text-slate-300 transition-colors group-hover:text-indigo-300" />
-                                                        </span>
-                                                    </Link>
-                                                );
-                                            })}
-                                        </nav>
+                                        <div className="mt-6 rounded-2xl border border-slate-200/70 bg-white/70 px-5 py-4 text-sm font-semibold leading-relaxed text-slate-700 shadow-sm">
+                                            {t('navigation.mobileHint', '주요 내비게이션은 데스크톱 화면에서 이용할 수 있어요.')}
+                                        </div>
 
                                         <div className="mt-6">
                                             <Link

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -7,29 +7,25 @@ export default function Login() {
     return (
         <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 text-white">
             <div className="pointer-events-none absolute inset-0">
-                <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950" />
-                <div className="absolute left-1/2 top-0 h-72 w-72 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/30 blur-3xl" />
-                <div className="absolute bottom-10 left-4 h-48 w-48 rounded-full bg-sky-500/10 blur-3xl" />
-                <div className="absolute bottom-0 right-0 h-80 w-80 translate-x-1/3 translate-y-1/3 rounded-full bg-purple-500/20 blur-3xl" />
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_-10%,rgba(99,102,241,0.28),transparent_55%),radial-gradient(circle_at_80%_-10%,rgba(56,189,248,0.22),transparent_50%)]" />
+                <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 opacity-95" />
+                <div className="absolute left-1/2 top-0 h-80 w-80 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/25 blur-3xl" />
             </div>
 
             <div className="relative z-10 flex min-h-screen flex-col">
                 <Navigation />
 
-                <main className="flex flex-1 flex-col items-center px-6 pb-16 pt-12 sm:px-8 lg:px-12">
+                <main className="flex flex-1 flex-col items-center px-6 pb-16 pt-28 sm:px-8 sm:pt-32 lg:px-12">
                     <section className="w-full max-w-xl space-y-6 text-center lg:space-y-8">
-                        <div className="space-y-3">
-                            <p className="text-xs font-semibold uppercase tracking-[0.45em] text-indigo-200">Log in</p>
-                            <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">
-                                계정에 접속해 작업을 이어가세요
-                            </h1>
+                        <div className="space-y-4">
+                            <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">콘솔 로그인</h1>
                             <p className="text-sm leading-relaxed text-slate-200/80 sm:text-base">
-                                Gravifox 보안 콘솔에 로그인하고 팀의 프로젝트와 데이터를 한곳에서 관리하세요.
+                                팀 인증을 완료하고 작업을 계속하세요.
                             </p>
                         </div>
                     </section>
 
-                    <section className="mt-10 w-full max-w-md sm:mt-12">
+                    <section className="mt-12 w-full max-w-md sm:mt-14">
                         <SignInForm />
                     </section>
                 </main>


### PR DESCRIPTION
## 변경 목적
- 모바일에서 앵커 내비게이션이 과도하게 노출되고 로그인 콘텐츠가 내비게이션에 가려지는 문제를 해결했어요.
- 로그인 화면의 텍스트와 시각 효과를 정리해 미래지향적이고 깔끔한 인상을 주도록 개선했어요.

## 주요 변경점
- 로그인 페이지 배경을 정돈하고 상단 여백을 늘려 내비게이션과의 겹침을 제거했어요.
- 로그인 폼의 문구와 스타일을 간결한 톤으로 조정하고 입력/버튼 스타일을 미래지향적으로 다듬었어요.
- 모바일 내비게이션에서 앵커 링크 목록을 제거하고 데스크톱 전용임을 안내하는 메시지로 대체했어요.

## 테스트 결과 요약
- Playwright로 로컬 개발 서버에 접속해 데스크톱/모바일 뷰를 캡처하며 UI를 확인했어요.

## 보안·성능 고려사항
- 추가적인 네트워크 호출이나 민감 정보 노출은 발생하지 않았어요.

## 관련 이슈 번호
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68e215732dfc8323a3c23f0d3ef04ee9