### PR TITLE
[refactor] 메인 페이지 섹션과 내비게이션을 정리했어요

### DIFF
--- a/public/locales/en/home.json
+++ b/public/locales/en/home.json
@@ -46,7 +46,9 @@
         "desc": "Drag a file or paste a link and get the verdict and explanation in seconds."
       }
     ],
-    "cardsLabel": "Quick start"
+    "cardsLabel": "Quick start",
+    "usageLabel": "How to use",
+    "usageDescription": "Start an analysis and review the verdict in just three steps."
   },
   "cta": {
     "start": "Get started free",
@@ -320,7 +322,8 @@
     "sample": "Sample",
     "security": "Security",
     "faq": "FAQ",
-    "testimonials": "Stories"
+    "testimonials": "Stories",
+    "progressLabel": "Scroll progress"
   },
   "meta": {
     "title": "GraviFox — GenAI image authenticity API",

--- a/public/locales/ko/home.json
+++ b/public/locales/ko/home.json
@@ -46,7 +46,9 @@
         "desc": "파일을 드래그하거나 링크만 넣으면 몇 초 뒤 결과와 설명을 받아요."
       }
     ],
-    "cardsLabel": "바로 써보기"
+    "cardsLabel": "바로 써보기",
+    "usageLabel": "이용 방법",
+    "usageDescription": "세 단계만으로 업로드하고 분석 결과를 확인하세요."
   },
   "cta": {
     "start": "무료로 시작하기",
@@ -302,7 +304,8 @@
     "sample": "샘플",
     "security": "보안",
     "faq": "FAQ",
-    "testimonials": "스토리"
+    "testimonials": "스토리",
+    "progressLabel": "스크롤 진행도"
   },
   "meta": {
     "title": "GraviFox — AI 이미지 진위 판별 API",

--- a/src/features/main/anchorNav.js
+++ b/src/features/main/anchorNav.js
@@ -1,61 +1,14 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  PlayIcon,
-  SparklesIcon,
-  Squares2X2Icon,
-  BriefcaseIcon,
-  RectangleStackIcon,
-  CodeBracketIcon,
-  ShieldCheckIcon,
-  QuestionMarkCircleIcon,
-  ChatBubbleLeftRightIcon,
-} from '@heroicons/react/24/outline';
 
 export default function AnchorNav() {
   const { t } = useTranslation('home');
-  const iconMap = {
-    how: PlayIcon,
-    value: SparklesIcon,
-    feature: Squares2X2Icon,
-    'use-cases': BriefcaseIcon,
-    supported: RectangleStackIcon,
-    sample: CodeBracketIcon,
-    security: ShieldCheckIcon,
-    faq: QuestionMarkCircleIcon,
-    testimonials: ChatBubbleLeftRightIcon,
-  };
-  const items = useMemo(() => ([
-    { id: 'how', label: t('anchor.how', 'How it works') },
-    { id: 'value', label: t('anchor.value', 'Why Gravifox') },
-    { id: 'feature', label: t('anchor.feature', 'Features') },
-    { id: 'use-cases', label: t('anchor.useCases', 'Use cases') },
-    { id: 'supported', label: t('anchor.supported', 'Formats') },
-    { id: 'sample', label: t('anchor.sample', 'Sample') },
-    { id: 'security', label: t('anchor.security', 'Security') },
-    { id: 'faq', label: t('anchor.faq', 'FAQ') },
-    { id: 'testimonials', label: t('anchor.testimonials', 'Stories') },
-  ]), [t]);
-
-  const [active, setActive] = useState(items[0].id);
-  const navRef = useRef(null);
+  const sectionIds = useMemo(
+    () => ['how', 'feature', 'use-cases', 'supported', 'sample', 'security', 'faq'],
+    []
+  );
+  const [progress, setProgress] = useState(0);
   const [headerOffset, setHeaderOffset] = useState(72);
-
-  useEffect(() => {
-    const obs = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) setActive(entry.target.id);
-        });
-      },
-      { rootMargin: '-40% 0px -55% 0px', threshold: 0.01 }
-    );
-    items.forEach(({ id }) => {
-      const el = document.getElementById(id);
-      if (el) obs.observe(el);
-    });
-    return () => obs.disconnect();
-  }, [items]);
 
   useEffect(() => {
     let ticking = false;
@@ -89,57 +42,72 @@ export default function AnchorNav() {
     };
   }, []);
 
-  const onClick = (e, id) => {
-    e.preventDefault();
-    const el = document.getElementById(id);
-    if (!el) return;
-    // Compute dynamic offset: header (fixed) + anchor nav (sticky) heights
-    const header = document.querySelector('header');
-    const headerRect = header ? header.getBoundingClientRect() : { top: 0, height: 64 };
-    const headerGap = window.innerWidth < 1024 ? 12 : 8;
-    const headerH = (headerRect?.top || 0) + (headerRect?.height || 64) + headerGap;
-    const anchorH = navRef.current ? navRef.current.getBoundingClientRect().height : 48;
-    const extra = window.innerWidth < 1024 ? 20 : 12; // tighter breathing room since header shrinks more
-    const y = el.getBoundingClientRect().top + window.scrollY - (headerH + anchorH + extra);
-    window.scrollTo({ top: y, behavior: 'smooth' });
-  };
+  useEffect(() => {
+    let animationFrame = null;
+    const calculateProgress = () => {
+      const elements = sectionIds
+        .map((id) => document.getElementById(id))
+        .filter(Boolean);
+      if (!elements.length) {
+        setProgress(0);
+        return;
+      }
+      const firstRect = elements[0].getBoundingClientRect();
+      const lastRect = elements[elements.length - 1].getBoundingClientRect();
+      const firstTop = firstRect.top + window.scrollY;
+      const lastBottom = lastRect.bottom + window.scrollY;
+      const range = lastBottom - window.innerHeight - firstTop;
+
+      if (range <= 0) {
+        const reachedEnd = window.scrollY + window.innerHeight >= lastBottom;
+        setProgress(reachedEnd ? 1 : 0);
+        return;
+      }
+
+      const raw = (window.scrollY - firstTop) / range;
+      const clamped = Math.min(1, Math.max(0, raw));
+      setProgress(clamped);
+    };
+
+    const handle = () => {
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      animationFrame = window.requestAnimationFrame(calculateProgress);
+    };
+
+    calculateProgress();
+    window.addEventListener('scroll', handle, { passive: true });
+    window.addEventListener('resize', handle);
+    return () => {
+      if (animationFrame) cancelAnimationFrame(animationFrame);
+      window.removeEventListener('scroll', handle);
+      window.removeEventListener('resize', handle);
+    };
+  }, [sectionIds]);
 
   return (
     <nav
-      ref={navRef}
       id="anchor-nav"
       className="sticky z-20 w-full border-b border-slate-200 bg-white/90 backdrop-blur supports-[backdrop-filter]:bg-white/70"
       style={{ top: headerOffset }}
     >
       <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
-        <ul className="flex flex-nowrap items-center gap-2 overflow-x-auto py-3 text-sm no-scrollbar">
-          {items.map((it) => {
-            const Icon = iconMap[it.id] || PlayIcon;
-            const isActive = active === it.id;
-            return (
-              <li key={it.id}>
-                <a
-                  href={`#${it.id}`}
-                  aria-current={isActive ? 'true' : undefined}
-                  aria-label={it.label}
-                  onClick={(e) => onClick(e, it.id)}
-                  tabIndex={0}
-                  className={`relative inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-400 ${
-                    isActive
-                      ? 'bg-indigo-50 text-indigo-700 ring-1 ring-indigo-200'
-                      : 'text-slate-600 hover:text-slate-900'
-                  }`}
-                >
-                  <Icon className="h-4 w-4" aria-hidden="true" />
-                  <span className="font-medium">{it.label}</span>
-                  {isActive && (
-                    <span className="pointer-events-none absolute -bottom-1 left-1/2 h-0.5 w-8 -translate-x-1/2 rounded-full bg-indigo-500" />
-                  )}
-                </a>
-              </li>
-            );
-          })}
-        </ul>
+        <div className="flex flex-col gap-2 py-4 sm:flex-row sm:items-center sm:gap-4">
+          <div className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-500">
+            {t('anchor.progressLabel', 'Scroll progress')}
+          </div>
+          <div className="flex flex-1 items-center gap-3">
+            <div className="relative h-2 flex-1 overflow-hidden rounded-full bg-slate-200/80">
+              <div
+                className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-indigo-500 via-indigo-400 to-indigo-600 transition-[width] duration-200"
+                style={{ width: `${Math.round(Math.min(1, Math.max(0, progress)) * 100)}%` }}
+                aria-hidden="true"
+              />
+            </div>
+            <div className="text-xs font-medium text-slate-600">
+              {`${Math.round(Math.min(1, Math.max(0, progress)) * 100)}%`}
+            </div>
+          </div>
+        </div>
       </div>
     </nav>
   );

--- a/src/features/main/pageSection.js
+++ b/src/features/main/pageSection.js
@@ -1,8 +1,6 @@
 import { useTranslation } from 'react-i18next';
-import { ArrowOutward, HeadsetMic, CheckCircle } from '@mui/icons-material';
-import { Bug, Lightbulb, MessageSquare } from "lucide-react";
-import { Sparkles } from "lucide-react";
-import { Upload, ScanSearch, CheckCircle2 } from "lucide-react";
+import { ArrowOutward } from '@mui/icons-material';
+import { MessageSquare, Sparkles, Upload, ScanSearch, CheckCircle2 } from "lucide-react";
 
 export default function PageSection() {
     const { t, i18n } = useTranslation('home');
@@ -13,32 +11,11 @@ export default function PageSection() {
         { icon: ScanSearch, value: "분석", desc: "AI의 흔적을 찾고 주요 특징을 빠르게 분석합니다." },
         { icon: CheckCircle2, value: "판별", desc: "진위 판단과 함께 분석 근거를 보여드립니다." },
     ];
-
-
-    const bulletPoints = t('hero.bullets', {
-        returnObjects: true,
-        defaultValue: [
-            'Upload any photo to check if it looks AI-generated in seconds.',
-            'Review the highlighted clues that explain the verdict.',
-            'Share a simple link so anyone can see the result.',
-        ],
-    });
-
-    const quickGuides = t('hero.cards', {
-        returnObjects: true,
-        defaultValue: [
-            {
-                title: 'Try it first with a sample',
-                desc: 'Open a sample image to watch the analysis unfold in real time.',
-            },
-            {
-                title: 'Upload your own photo',
-                desc: 'Drag a file or paste a link and get the verdict within seconds.',
-            },
-        ],
-    }).slice(0, 2);
-
-    const cardsLabel = t('hero.cardsLabel', 'Quick start');
+    const usageLabel = t('hero.usageLabel', 'How to use');
+    const usageDescription = t(
+        'hero.usageDescription',
+        '세 단계만으로 분석을 시작하고 결과를 받아보세요.'
+    );
 
     return (
         <section className="relative isolate overflow-hidden">
@@ -65,7 +42,7 @@ export default function PageSection() {
                 </div>
 
 
-                <div className="mt-4 grid gap-12 lg:grid-cols-[1.25fr_0.9fr] lg:items-center">
+                <div className="mt-4 space-y-12">
                     <div className="space-y-8 text-indigo-50">
                         <div className="space-y-5">
                             <h1 className="text-[22px] sm:text-4xl md:text-5xl lg:text-6xl font-extrabold tracking-tight leading-tight">
@@ -135,11 +112,19 @@ export default function PageSection() {
 
                         </div>
 
-                        <div className="grid gap-4 sm:grid-cols-3">
-                            {metrics.map((metric, i) => (
-                                <div
-                                    key={metric.value}
-                                    className="
+                        <div className="space-y-4">
+                            <div className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/10 px-4 py-1 text-[10px] sm:text-xs font-semibold uppercase tracking-[0.18em] text-indigo-200/80">
+                                <Sparkles className="h-3.5 w-3.5" />
+                                <span>{usageLabel}</span>
+                            </div>
+                            <p className="max-w-2xl text-sm sm:text-base text-indigo-100/80">
+                                {usageDescription}
+                            </p>
+                            <div className="grid gap-4 sm:grid-cols-3">
+                                {metrics.map((metric) => (
+                                    <div
+                                        key={metric.value}
+                                        className="
             group relative overflow-hidden
             rounded-2xl border border-white/10 bg-white/[0.06]
             px-5 py-5
@@ -149,59 +134,23 @@ export default function PageSection() {
             hover:bg-white/[0.12] hover:translate-y-[-2px]
             hover:shadow-[0_12px_40px_-20px_rgba(129,140,248,0.4)]
           "
-                                >
-                                    <div className="flex items-center gap-3">
-                                        <metric.icon className="h-5 w-5 text-indigo-300/90 transition-transform duration-300 group-hover:scale-110" />
-                                        <h3 className="text-base font-semibold text-white tracking-tight">
-                                            {metric.value}
-                                        </h3>
+                                    >
+                                        <div className="flex items-center gap-3">
+                                            <metric.icon className="h-5 w-5 text-indigo-300/90 transition-transform duration-300 group-hover:scale-110" />
+                                            <h3 className="text-base font-semibold text-white tracking-tight">
+                                                {metric.value}
+                                            </h3>
+                                        </div>
+                                        <p className="mt-2 text-[13px] leading-relaxed text-indigo-100/80">
+                                            {metric.desc}
+                                        </p>
+
+                                        <div className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-tr from-indigo-400/10 to-transparent" />
                                     </div>
-                                    <p className="mt-2 text-[13px] leading-relaxed text-indigo-100/80">
-                                        {metric.desc}
-                                    </p>
-
-                                    {/* subtle gradient glow */}
-                                    <div className="pointer-events-none absolute inset-0 opacity-0 group-hover:opacity-100 transition-opacity duration-300 bg-gradient-to-tr from-indigo-400/10 to-transparent" />
-                                </div>
-                            ))}
+                                ))}
+                            </div>
                         </div>
-
-                        {/*<ul className="mt-6 space-y-3 text-sm text-indigo-100/80">*/}
-                        {/*    {bulletPoints.map((line, idx) => (*/}
-                        {/*        <li key={idx} className="flex items-start gap-2">*/}
-                        {/*            <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-emerald-300" />*/}
-                        {/*            <span>{line}</span>*/}
-                        {/*        </li>*/}
-                        {/*    ))}*/}
-                        {/*</ul>*/}
                     </div>
-
-                    {quickGuides.length > 0 && (
-                        <div className="relative flex flex-col gap-4">
-                            {quickGuides.map((card, idx) => (
-                                <article
-                                    key={`${card.title}-${idx}`}
-                                    className="relative overflow-hidden rounded-3xl border border-white/15 bg-white/10 p-6 text-indigo-100 shadow-[0_30px_60px_-35px_rgba(15,23,42,0.95)] backdrop-blur"
-                                >
-                                    <div className="absolute inset-0 bg-gradient-to-br from-white/18 via-indigo-400/10 to-white/5" aria-hidden="true" />
-                                    <div className="relative flex flex-col gap-3">
-                                        <div className="flex items-center gap-3 text-xs font-semibold uppercase tracking-[0.2em] text-indigo-200/90">
-                                            <span className="flex h-8 w-8 items-center justify-center rounded-full border border-white/20 bg-white/10 text-sm text-indigo-50">
-                                                {String(idx + 1)}
-                                            </span>
-                                            <span className="text-indigo-100/80">{cardsLabel}</span>
-                                        </div>
-                                        <div className="space-y-2">
-                                            <h3 className="text-lg font-semibold text-white">{card.title}</h3>
-                                            {card.desc && (
-                                                <p className="text-sm leading-relaxed text-indigo-100/80">{card.desc}</p>
-                                            )}
-                                        </div>
-                                    </div>
-                                </article>
-                            ))}
-                        </div>
-                    )}
                 </div>
             </div>
         </section>

--- a/src/pages/main.js
+++ b/src/pages/main.js
@@ -5,12 +5,10 @@ import Footer from "../features/footer/footer";
 import PageSection from "features/main/pageSection";
 import Feature from "features/main/feature";
 import HowItWorks from "features/main/howItWorks";
-import ValueProps from "features/main/valueProps";
 import SupportedInputs from "features/main/supportedInputs";
 import SampleOutput from "features/main/sampleOutput";
 import SecurityPrivacy from "features/main/securityPrivacy";
 import FAQ from "features/main/faq";
-import Testimonials from "features/main/testimonials";
 import AnchorNav from "features/main/anchorNav";
 import UseCases from "features/main/useCases";
 import ContentDecor from "features/main/contentDecor";
@@ -23,14 +21,12 @@ const Main = () => {
             <AnchorNav/>
             <ContentDecor>
                 <HowItWorks/>
-                <ValueProps/>
                 <Feature/>
                 <UseCases/>
                 <SupportedInputs/>
                 <SampleOutput/>
                 <SecurityPrivacy/>
                 <FAQ/>
-                <Testimonials/>
                 {/* Removed MainText per request */}
                 <Footer transparent />
             </ContentDecor>


### PR DESCRIPTION
## 변경 목적
- 사용자 이야기와 왜 Gravifox 섹션을 제외하고, 진행률 기반 내비게이션으로 전환했어요.

## 주요 변경점
- AnchorNav 컴포넌트를 스크롤 프로그래스 바로 교체했어요.
- 메인 페이지에서 사용자 이야기/왜 Gravifox 섹션을 제거하고 히어로 영역에 이용 방법 안내를 추가했어요.
- 번역 리소스에 진행도와 이용 방법 문구를 추가했어요.

## 테스트 결과 요약
- `npm run build`를 실행해서 프로덕션 빌드를 확인했어요.

## 보안·성능 고려사항
- 별도의 보안이나 성능 이슈는 없어요.

## 관련 이슈 번호
- 해당 사항 없어요.


------
https://chatgpt.com/codex/tasks/task_e_68e21d2b4f6c8323a3ab1b20d868b17f