### PR TITLE
[fix] 모바일 내비게이션 카테고리 복원했어요

### DIFF
--- a/src/features/navigation/navigation.js
+++ b/src/features/navigation/navigation.js
@@ -379,8 +379,38 @@ const Navigation = () => {
                                             </button>
                                         </div>
 
-                                        <div className="mt-6 rounded-2xl border border-slate-200/70 bg-white/70 px-5 py-4 text-sm font-semibold leading-relaxed text-slate-700 shadow-sm">
-                                            {t('navigation.mobileHint', '주요 내비게이션은 데스크톱 화면에서 이용할 수 있어요.')}
+                                        <div className="mt-6">
+                                            <nav aria-label={t('navigation.mobileMenuLabel', '주요 내비게이션')}>
+                                                <ul className="flex flex-col gap-2">
+                                                    {navItems.map((item) => {
+                                                        const isActive = activeItemKey === item.key;
+                                                        return (
+                                                            <li key={item.key}>
+                                                                <Link
+                                                                    to={buildLinkTarget(item)}
+                                                                    onClick={() => setMobileMenuOpen(false)}
+                                                                    aria-current={isActive ? 'page' : undefined}
+                                                                    className={`flex items-center justify-between rounded-2xl border px-4 py-3 text-base font-semibold transition-all duration-200 ${
+                                                                        isActive
+                                                                            ? 'border-indigo-200 bg-indigo-50 text-indigo-600 shadow-sm'
+                                                                            : 'border-slate-200/60 bg-white text-slate-700 hover:border-indigo-100 hover:bg-indigo-50/70 hover:text-indigo-600'
+                                                                    }`}
+                                                                >
+                                                                    <span>{t(item.labelKey)}</span>
+                                                                    <span
+                                                                        aria-hidden="true"
+                                                                        className={`text-sm font-medium transition-transform duration-200 ${
+                                                                            isActive ? 'translate-x-0 text-indigo-500' : 'translate-x-1 text-slate-400'
+                                                                        }`}
+                                                                    >
+                                                                        →
+                                                                    </span>
+                                                                </Link>
+                                                            </li>
+                                                        );
+                                                    })}
+                                                </ul>
+                                            </nav>
                                         </div>
 
                                         <div className="mt-6">


### PR DESCRIPTION
## 변경 목적
- 모바일 내비게이션에서 데스크톱 전용 안내 문구만 보여서 주요 카테고리를 바로 이용하기 어려운 문제를 해결했어요.

## 주요 변경점
- 모바일 메뉴 패널에 데스크톱과 동일한 내비게이션 카테고리 링크를 추가하고, 링크 클릭 시 메뉴가 닫히도록 했어요.

## 테스트 결과 요약
- `npm test -- --watchAll=false` 명령이 `react-router-dom` 모듈을 찾지 못해 실패했어요.

## 보안·성능 고려사항
- 보안과 성능에 영향을 주는 변경 사항은 없어요.

## 관련 이슈 번호
- 없어요.


------
https://chatgpt.com/codex/tasks/task_e_68e22bfea9c483238178d0c8df91f177