### PR TITLE
[fix] Footer 반응형 레이아웃을 개선했어요

### DIFF
--- a/src/features/footer/footer.js
+++ b/src/features/footer/footer.js
@@ -31,45 +31,46 @@ const Footer = ({ transparent = false }) => {
     return (
         <section className={transparent ? "bg-transparent" : "bg-white"}>
             <div className="max-w-screen-xl px-4 py-12 mx-auto space-y-6 overflow-hidden sm:px-6 lg:px-8">
-                <nav className="flex flex-wrap items-center justify-center gap-4 text-sm">
-                    <button
-                        type="button"
-                        onClick={() => goTo('/feature')}
-                        className="text-sm leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                        About
-                    </button>
-                    <span className="text-gray-300">·</span>
-                    <button
-                        type="button"
-                        onClick={() => goTo('/support')}
-                        className="text-sm leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                        Contact
-                    </button>
-                    <span className="text-gray-300">·</span>
-                    <button
-                        type="button"
-                        onClick={() => goTo('/docs')}
-                        className="text-sm leading-6 text-gray-500 hover:text-gray-900"
-                    >
-                        Terms
-                    </button>
-                    <span className="text-gray-300">·</span>
-                    <div className="inline-flex items-center gap-2">
+                <nav className="flex flex-col items-center gap-6 text-sm sm:flex-row sm:flex-wrap sm:justify-center">
+                    <div className="flex flex-col items-center gap-4 text-sm sm:flex-row sm:items-center">
+                        <button
+                            type="button"
+                            onClick={() => goTo('/feature')}
+                            className="text-sm leading-6 text-gray-500 hover:text-gray-900"
+                        >
+                            About
+                        </button>
+                        <span className="hidden text-gray-300 sm:inline">·</span>
+                        <button
+                            type="button"
+                            onClick={() => goTo('/support')}
+                            className="text-sm leading-6 text-gray-500 hover:text-gray-900"
+                        >
+                            Contact
+                        </button>
+                        <span className="hidden text-gray-300 sm:inline">·</span>
+                        <button
+                            type="button"
+                            onClick={() => goTo('/docs')}
+                            className="text-sm leading-6 text-gray-500 hover:text-gray-900"
+                        >
+                            Terms
+                        </button>
+                    </div>
+                    <div className="flex flex-col items-center gap-2 sm:flex-row">
                         <span className="text-sm text-gray-500">Language</span>
                         <div className="inline-flex rounded-md ring-1 ring-gray-200 overflow-hidden">
                             <button
                                 type="button"
                                 onClick={() => changeLanguage('en')}
-                            className={`px-3 py-1.5 text-sm font-medium ${currentLng === 'en' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                className={`px-3 py-1.5 text-sm font-medium ${currentLng === 'en' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                             >
                                 EN
                             </button>
                             <button
                                 type="button"
                                 onClick={() => changeLanguage('ko')}
-                            className={`px-3 py-1.5 text-sm font-medium ${currentLng === 'ko' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
+                                className={`px-3 py-1.5 text-sm font-medium ${currentLng === 'ko' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`}
                             >
                                 KO
                             </button>


### PR DESCRIPTION
## 변경 목적
- 모바일 환경에서 Footer 메뉴가 겹치는 문제를 해결하려고 했어요.

## 주요 변경점
- Footer 네비게이션을 세로/가로로 전환되는 반응형 레이아웃으로 재구성했어요.

## 테스트 결과 요약
- 수동 테스트: 개발 서버를 실행하려 했지만 환경 문제로 페이지 로딩에 실패했어요.

## 보안·성능 고려사항
- 별도 영향 없어요.

## 관련 이슈 번호
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68e32b81c6108323ae8da37c96bc6b39