### PR TITLE
[fix] 모바일 푸터 정렬이 깨졌어요

### DIFF
--- a/src/features/footer/footer.js
+++ b/src/features/footer/footer.js
@@ -31,8 +31,8 @@ const Footer = ({ transparent = false }) => {
     return (
         <section className={transparent ? "bg-transparent" : "bg-white"}>
             <div className="max-w-screen-xl px-4 py-12 mx-auto space-y-6 overflow-hidden sm:px-6 lg:px-8">
-                <nav className="flex flex-col items-center gap-6 text-sm sm:flex-row sm:flex-wrap sm:justify-center">
-                    <div className="flex flex-col items-center gap-4 text-sm sm:flex-row sm:items-center">
+                <nav className="flex flex-wrap items-center justify-center gap-x-6 gap-y-4 text-sm">
+                    <div className="flex flex-wrap items-center justify-center gap-x-4 gap-y-2 text-sm">
                         <button
                             type="button"
                             onClick={() => goTo('/feature')}
@@ -40,7 +40,7 @@ const Footer = ({ transparent = false }) => {
                         >
                             About
                         </button>
-                        <span className="hidden text-gray-300 sm:inline">·</span>
+                        <span className="text-gray-300">·</span>
                         <button
                             type="button"
                             onClick={() => goTo('/support')}
@@ -48,7 +48,7 @@ const Footer = ({ transparent = false }) => {
                         >
                             Contact
                         </button>
-                        <span className="hidden text-gray-300 sm:inline">·</span>
+                        <span className="text-gray-300">·</span>
                         <button
                             type="button"
                             onClick={() => goTo('/docs')}
@@ -57,9 +57,9 @@ const Footer = ({ transparent = false }) => {
                             Terms
                         </button>
                     </div>
-                    <div className="flex flex-col items-center gap-2 sm:flex-row">
+                    <div className="flex flex-wrap items-center justify-center gap-2">
                         <span className="text-sm text-gray-500">Language</span>
-                        <div className="inline-flex rounded-md ring-1 ring-gray-200 overflow-hidden">
+                        <div className="inline-flex overflow-hidden rounded-md ring-1 ring-gray-200">
                             <button
                                 type="button"
                                 onClick={() => changeLanguage('en')}


### PR DESCRIPTION
## 변경 목적
- 모바일 화면에서 푸터 메뉴가 여러 줄로 쌓여 가독성이 떨어지는 문제를 해결하려고 했어요.

## 주요 변경점
- `src/features/footer/footer.js`에서 네비게이션과 언어 선택 영역의 flex 레이아웃을 조정해서 모바일에서도 한 줄로 배치되도록 했어요.

## 테스트 결과 요약
- 별도의 자동화 테스트는 수행하지 않았어요.

## 보안·성능 고려사항
- 보안이나 성능에 영향을 주는 변경은 없어요.

## 관련 이슈 번호
- 해당 사항 없어요.

------
https://chatgpt.com/codex/tasks/task_e_68e3335ed55883238e0c33d5c8053fd8