### PR TITLE
[style] 로그인 화면을 더 고급스럽게 다듬었어요

### DIFF
--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -15,18 +15,18 @@ export default function Login() {
             <div className="relative z-10 flex min-h-screen flex-col">
                 <Navigation />
 
-                <main className="flex flex-1 flex-col items-center px-6 pb-16 pt-28 sm:px-8 sm:pt-32 lg:px-12">
-                    <section className="w-full max-w-xl space-y-6 text-center lg:space-y-8">
-                        <div className="space-y-4">
-                            <h1 className="text-3xl font-semibold leading-tight text-white sm:text-4xl">콘솔 로그인</h1>
-                            <p className="text-sm leading-relaxed text-slate-200/80 sm:text-base">
-                                팀 인증을 완료하고 작업을 계속하세요.
-                            </p>
-                        </div>
-                    </section>
+                <main className="flex flex-1 flex-col items-center justify-center px-6 pb-16 pt-28 sm:px-8 sm:pt-32 lg:px-12">
+                    <section className="w-full max-w-md">
+                        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-white/20 via-white/10 to-white/5 p-[1px] shadow-[0_25px_80px_-20px_rgba(56,189,248,0.35)]">
+                            <div className="relative rounded-[calc(1.5rem-1px)] bg-slate-950/75 px-8 py-10 backdrop-blur-xl sm:px-10 sm:py-12">
+                                <div className="pointer-events-none absolute inset-x-10 -top-24 h-40 rounded-full bg-gradient-to-br from-indigo-400/50 via-cyan-300/40 to-transparent blur-3xl" />
+                                <div className="absolute inset-0 rounded-[calc(1.5rem-1px)] border border-white/10" />
 
-                    <section className="mt-12 w-full max-w-md sm:mt-14">
-                        <SignInForm />
+                                <div className="relative z-10">
+                                    <SignInForm />
+                                </div>
+                            </div>
+                        </div>
                     </section>
                 </main>
 


### PR DESCRIPTION
## 변경 목적
- 로그인 페이지의 타이틀과 부제목을 제거하고, 로그인 컨테이너를 보다 고급스럽게 연출하려고 했어요.

## 주요 변경점
- 로그인 메인 섹션에서 제목과 부제목을 제거했어요.
- 로그인 폼을 감싸는 컨테이너에 그라데이션 보더와 블러 효과를 적용해 고급스러운 카드 형태로 바꿨어요.

## 테스트 결과 요약
- 별도의 자동화 테스트를 실행하지 않았어요.

## 보안·성능 고려사항
- UI 스타일링 변경만 있어서 보안이나 성능에 영향이 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e334c6bd6c832398f16a749d8a3e08