### PR TITLE
[fix] 인증 초기 게이트 타임아웃을 처리했어요

### DIFF
--- a/src/providers/authProvider.js
+++ b/src/providers/authProvider.js
@@ -6,7 +6,31 @@ import { isTokenValid, getExpiryMs, decodeJwt } from "../utils/jwt";
 import { AUTH_ENDPOINTS, PROFILE_ENDPOINTS } from "../api/endPointRoute";
 import { getProfileCache, setProfileCache, clearProfileCache } from "../utils/profileCache";
 
+const BOOTSTRAP_TIMEOUT_MS = 15000;
+
 const AuthContext = createContext();
+
+const createTimeoutError = () => {
+    const error = new Error('BOOTSTRAP_TIMEOUT');
+    error.code = 'BOOTSTRAP_TIMEOUT';
+    return error;
+};
+
+const withTimeout = (promise, timeoutMs) => new Promise((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+        reject(createTimeoutError());
+    }, timeoutMs);
+
+    promise
+        .then((value) => {
+            clearTimeout(timeoutId);
+            resolve(value);
+        })
+        .catch((error) => {
+            clearTimeout(timeoutId);
+            reject(error);
+        });
+});
 
 export const AuthProvider = ({ children }) => {
     const [accessToken, setAccessToken] = useState(null);
@@ -14,6 +38,8 @@ export const AuthProvider = ({ children }) => {
     const [isLoading, setIsLoading] = useState(true);
     // 앱 시작 시 로그인 확인이 끝날 때까지 화면을 가리기 위한 게이트
     const [isChecking, setIsChecking] = useState(true);
+    const [bootstrapError, setBootstrapError] = useState(null);
+    const [bootstrapKey, setBootstrapKey] = useState(0);
 
     const logout = () => {
         setAccessToken(null);
@@ -49,6 +75,7 @@ export const AuthProvider = ({ children }) => {
     useEffect(() => {
         const bootstrap = async () => {
             try {
+                setBootstrapError(null);
                 // 게스트는 초기 체크만 끝내고 진행
                 const isGuest = (() => {
                     try { return typeof document !== 'undefined' && document.cookie && document.cookie.includes('guest=1'); } catch { return false; }
@@ -60,7 +87,10 @@ export const AuthProvider = ({ children }) => {
                 // 1) AccessToken 확보 (없으면 refresh 시도)
                 let at = accessToken;
                 if (!at) {
-                    const response = await axios.post(AUTH_ENDPOINTS.REFRESH, {}, { withCredentials: true });
+                    const response = await withTimeout(
+                        axios.post(AUTH_ENDPOINTS.REFRESH, {}, { withCredentials: true }),
+                        BOOTSTRAP_TIMEOUT_MS
+                    );
                     const next = response?.data?.accessToken;
                     if (next && isTokenValid(next)) {
                         setAccessToken(next);
@@ -97,7 +127,10 @@ export const AuthProvider = ({ children }) => {
                 try {
                     const headers = {};
                     if (cached?.etag) headers['If-None-Match'] = cached.etag;
-                    const resp = await axios.get(PROFILE_ENDPOINTS.GET_INFO, { headers });
+                    const resp = await withTimeout(
+                        axios.get(PROFILE_ENDPOINTS.GET_INFO, { headers }),
+                        BOOTSTRAP_TIMEOUT_MS
+                    );
                     // axios는 304도 성공으로 처리함. status로 분기
                     if (resp?.status === 200 && resp.data) {
                         const etag = resp.headers?.etag || resp.headers?.ETag;
@@ -109,13 +142,18 @@ export const AuthProvider = ({ children }) => {
                 }
             } catch (error) {
                 // 네트워크 오류 등은 초기화만 수행
+                if (error?.code === 'BOOTSTRAP_TIMEOUT' || error?.code === 'ECONNABORTED') {
+                    setBootstrapError('timeout');
+                } else {
+                    setBootstrapError('error');
+                }
             } finally {
                 setIsLoading(false);
                 setIsChecking(false);
             }
         };
         bootstrap();
-    }, [accessToken]);
+    }, [accessToken, bootstrapKey]);
 
     // 사전 만료 갱신 타이머: exp - 30초에 refresh 시도
     useEffect(() => {
@@ -143,14 +181,81 @@ export const AuthProvider = ({ children }) => {
         }, delay);
         return () => clearTimeout(id);
     }, [accessToken]);
-    // 앱 시작 확인 중에는 전체 흰 화면만 노출
+    const retryBootstrap = () => {
+        setIsChecking(true);
+        setIsLoading(true);
+        setBootstrapError(null);
+        setBootstrapKey((key) => key + 1);
+    };
+
+    let gateContent = null;
     if (isChecking) {
-        return <div style={{background: '#fff', width: '100vw', height: '100vh'}} />
+        gateContent = <div style={{background: '#fff', width: '100vw', height: '100vh'}} />;
+    } else if (bootstrapError === 'timeout') {
+        gateContent = (
+            <div style={{
+                background: '#fff',
+                width: '100vw',
+                height: '100vh',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '12px',
+                color: '#111'
+            }}>
+                <p style={{ fontSize: '16px', fontWeight: 500 }}>네트워크 응답이 지연되고 있어요.</p>
+                <button
+                    type="button"
+                    onClick={retryBootstrap}
+                    style={{
+                        padding: '10px 18px',
+                        borderRadius: '8px',
+                        border: '1px solid #111',
+                        background: '#111',
+                        color: '#fff',
+                        cursor: 'pointer'
+                    }}
+                >
+                    다시 시도하기
+                </button>
+            </div>
+        );
+    } else if (bootstrapError) {
+        gateContent = (
+            <div style={{
+                background: '#fff',
+                width: '100vw',
+                height: '100vh',
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: '12px',
+                color: '#111'
+            }}>
+                <p style={{ fontSize: '16px', fontWeight: 500 }}>로그인 상태를 확인하는 중 문제가 발생했어요.</p>
+                <button
+                    type="button"
+                    onClick={retryBootstrap}
+                    style={{
+                        padding: '10px 18px',
+                        borderRadius: '8px',
+                        border: '1px solid #111',
+                        background: '#111',
+                        color: '#fff',
+                        cursor: 'pointer'
+                    }}
+                >
+                    다시 시도하기
+                </button>
+            </div>
+        );
     }
 
     return (
-        <AuthContext.Provider value={{ accessToken, setAccessToken, userInfo, setUserInfo, logout, isLoading, isChecking }}>
-            {children}
+        <AuthContext.Provider value={{ accessToken, setAccessToken, userInfo, setUserInfo, logout, isLoading, isChecking, bootstrapError, retryBootstrap }}>
+            {gateContent || children}
         </AuthContext.Provider>
     );
 };


### PR DESCRIPTION
## 변경 목적
- 초기 인증 검증 단계에서 응답이 지연될 때 흰 화면에서 벗어나지 못하는 문제를 해결하려고 했어요.

## 주요 변경점
- `AuthProvider`에서 타임아웃을 적용해 응답 지연 시 예외 분기를 추가했어요.
- 타임아웃 및 기타 오류 상황에 대한 전용 게이트 화면과 재시도 동작을 제공했어요.

## 테스트 결과 요약
- 테스트를 실행하지 못했어요 (사유: 별도의 자동 테스트 없이 로직만 수정했어요).

## 보안·성능 고려사항
- 네트워크 요청에 타임아웃을 걸어 무한 대기 상태를 방지했어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e3408e9380832386f94a4b1f7dd083