### PR TITLE
[style] 로그인 페이지 레이아웃을 모바일 스타일로 다듬었어요

### DIFF
--- a/src/features/login/signInForm.js
+++ b/src/features/login/signInForm.js
@@ -65,85 +65,82 @@ export default function SignInForm() {
     };
 
     return (
-        <div className="relative mx-auto w-full max-w-md overflow-hidden rounded-[28px] border border-white/15 bg-white/8 shadow-[0_24px_60px_-28px_rgba(15,23,42,0.85)] backdrop-blur-2xl">
-            <div className="absolute inset-0 bg-[linear-gradient(135deg,rgba(148,163,255,0.18),transparent_45%),linear-gradient(225deg,rgba(56,189,248,0.12),transparent_55%)]" aria-hidden="true" />
-            <div className="relative px-6 py-8 sm:px-10 sm:py-10">
-                <div className="space-y-3 text-center text-white">
-                    <h2 className="text-2xl font-semibold sm:text-3xl">계정으로 로그인</h2>
-                    <p className="text-sm text-slate-200/80">보안 토큰을 입력하고 즉시 콘솔을 시작하세요.</p>
-                </div>
-                <form onSubmit={handleSubmit} className="mt-8 space-y-6">
-                    <div className="space-y-2">
-                        <label htmlFor="userId" className="block text-sm font-medium text-slate-100">
-                            Email address
-                        </label>
-                        <input
-                            id="userId"
-                            name="userId"
-                            type="text"
-                            autoComplete="email"
-                            value={formState.userId}
-                            onChange={handleInputChange("userId")}
-                            className="block w-full rounded-2xl border border-white/30 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-sky-300 focus:ring-2 focus:ring-sky-200"
-                        />
-                    </div>
-
-                    <div className="space-y-2">
-                        <div className="flex items-center justify-between">
-                            <label htmlFor="password" className="block text-sm font-medium text-slate-100">
-                                Password
-                            </label>
-                            <Link to={localizedPath("/support")} className="text-xs font-semibold text-indigo-200 transition hover:text-indigo-100">
-                                Forgot password?
-                            </Link>
-                        </div>
-                        <input
-                            id="password"
-                            name="password"
-                            type="password"
-                            autoComplete="current-password"
-                            value={formState.password}
-                            onChange={handleInputChange("password")}
-                            className="block w-full rounded-2xl border border-white/30 bg-white/90 px-4 py-3 text-sm font-medium text-slate-900 shadow-sm outline-none transition focus:border-sky-300 focus:ring-2 focus:ring-sky-200"
-                        />
-                    </div>
-
-                    <button
-                        type="submit"
-                        className="flex w-full justify-center rounded-2xl bg-gradient-to-r from-indigo-400 via-sky-500 to-emerald-400 px-4 py-3 text-sm font-semibold text-white shadow-[0_18px_42px_-20px_rgba(79,70,229,0.55)] transition hover:from-indigo-300 hover:via-sky-400 hover:to-emerald-300 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-sky-200"
-                    >
-                        Sign in
-                    </button>
-
-                    <div>
-                        <LoginErrorMessage
-                            status={errorStatus}
-                            message={errorMessage}
-                            onClose={() => {
-                                setErrorStatus(null);
-                                setErrorMessage(null);
-                            }}
-                        />
-                    </div>
-                </form>
-
-                <div className="relative mt-8 flex items-center">
-                    <span className="h-px flex-1 bg-white/10" />
-                    <span className="px-3 text-xs font-semibold tracking-[0.25em] text-slate-200/70">OR</span>
-                    <span className="h-px flex-1 bg-white/10" />
-                </div>
-
-                <div className="mt-6">
-                    <GoogleLoginButton />
-                </div>
-
-                <p className="mt-8 text-center text-sm text-slate-200/80">
-                    아직 멤버가 아니신가요?{' '}
-                    <button className="font-semibold text-indigo-200 transition hover:text-indigo-100" onClick={handleChangeForm}>
-                        가입하기
-                    </button>
-                </p>
+        <div className="mx-auto w-full max-w-sm rounded-2xl bg-white px-6 py-10 text-slate-900 shadow-lg sm:px-8">
+            <div className="space-y-2 text-center">
+                <h2 className="text-2xl font-semibold">계정으로 로그인</h2>
+                <p className="text-sm text-slate-500">보안 토큰을 입력하고 즉시 콘솔을 시작하세요.</p>
             </div>
+            <form onSubmit={handleSubmit} className="mt-8 space-y-5">
+                <div className="space-y-2">
+                    <label htmlFor="userId" className="block text-sm font-medium text-slate-700">
+                        Email address
+                    </label>
+                    <input
+                        id="userId"
+                        name="userId"
+                        type="text"
+                        autoComplete="email"
+                        value={formState.userId}
+                        onChange={handleInputChange("userId")}
+                        className="block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+                    />
+                </div>
+
+                <div className="space-y-2">
+                    <div className="flex items-center justify-between">
+                        <label htmlFor="password" className="block text-sm font-medium text-slate-700">
+                            Password
+                        </label>
+                        <Link to={localizedPath("/support")} className="text-xs font-semibold text-indigo-500 transition hover:text-indigo-400">
+                            Forgot password?
+                        </Link>
+                    </div>
+                    <input
+                        id="password"
+                        name="password"
+                        type="password"
+                        autoComplete="current-password"
+                        value={formState.password}
+                        onChange={handleInputChange("password")}
+                        className="block w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm font-medium text-slate-900 outline-none transition focus:border-indigo-400 focus:ring-2 focus:ring-indigo-200"
+                    />
+                </div>
+
+                <button
+                    type="submit"
+                    className="flex w-full justify-center rounded-xl bg-indigo-500 px-4 py-3 text-sm font-semibold text-white transition hover:bg-indigo-400 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-300"
+                >
+                    Sign in
+                </button>
+
+                <div>
+                    <LoginErrorMessage
+                        status={errorStatus}
+                        message={errorMessage}
+                        onClose={() => {
+                            setErrorStatus(null);
+                            setErrorMessage(null);
+                        }}
+                    />
+                </div>
+            </form>
+
+            <div className="relative mt-8 flex items-center">
+                <span className="h-px flex-1 bg-slate-200" />
+                <span className="px-3 text-xs font-semibold tracking-[0.25em] text-slate-400">OR</span>
+                <span className="h-px flex-1 bg-slate-200" />
+            </div>
+
+            <div className="mt-6">
+                <GoogleLoginButton />
+            </div>
+
+            <p className="mt-8 text-center text-sm text-slate-600">
+                아직 멤버가 아니신가요?{' '}
+                <button className="font-semibold text-indigo-500 transition hover:text-indigo-400" onClick={handleChangeForm}>
+                    가입하기
+                </button>
+            </p>
         </div>
     );
 }

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -5,33 +5,14 @@ import Footer from "../features/footer/footer";
 
 export default function Login() {
     return (
-        <div className="relative flex min-h-screen flex-col overflow-hidden bg-slate-950 text-white">
-            <div className="pointer-events-none absolute inset-0">
-                <div className="absolute inset-0 bg-[radial-gradient(circle_at_20%_-10%,rgba(99,102,241,0.28),transparent_55%),radial-gradient(circle_at_80%_-10%,rgba(56,189,248,0.22),transparent_50%)]" />
-                <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-900 to-indigo-950 opacity-95" />
-                <div className="absolute left-1/2 top-0 h-80 w-80 -translate-x-1/2 -translate-y-1/2 rounded-full bg-indigo-500/25 blur-3xl" />
-            </div>
+        <div className="flex min-h-screen flex-col bg-slate-950 text-white">
+            <Navigation />
 
-            <div className="relative z-10 flex min-h-screen flex-col">
-                <Navigation />
+            <main className="flex flex-1 flex-col items-center justify-center px-4 pb-16 pt-24 sm:px-6">
+                <SignInForm />
+            </main>
 
-                <main className="flex flex-1 flex-col items-center justify-center px-6 pb-16 pt-28 sm:px-8 sm:pt-32 lg:px-12">
-                    <section className="w-full max-w-md">
-                        <div className="relative overflow-hidden rounded-3xl bg-gradient-to-br from-white/20 via-white/10 to-white/5 p-[1px] shadow-[0_25px_80px_-20px_rgba(56,189,248,0.35)]">
-                            <div className="relative rounded-[calc(1.5rem-1px)] bg-slate-950/75 px-8 py-10 backdrop-blur-xl sm:px-10 sm:py-12">
-                                <div className="pointer-events-none absolute inset-x-10 -top-24 h-40 rounded-full bg-gradient-to-br from-indigo-400/50 via-cyan-300/40 to-transparent blur-3xl" />
-                                <div className="absolute inset-0 rounded-[calc(1.5rem-1px)] border border-white/10" />
-
-                                <div className="relative z-10">
-                                    <SignInForm />
-                                </div>
-                            </div>
-                        </div>
-                    </section>
-                </main>
-
-                <Footer transparent />
-            </div>
+            <Footer transparent />
         </div>
     );
 }


### PR DESCRIPTION
## 변경 목적
- 로그인 입력 박스가 중첩된 박스로 감싸져 있어 모바일 레이아웃과 거리가 있어 보였어요.
- 불필요한 장식을 제거하고 간결한 모바일 로그인 화면처럼 보이도록 조정했어요.

## 주요 변경점
- `src/pages/login.js`에서 로그인 페이지 배경 레이어를 제거하고 폼을 중앙 배치했어요.
- `src/features/login/signInForm.js`에서 박스 중첩을 제거하고 입력 필드/버튼 스타일을 모바일 친화적으로 단순화했어요.

## 테스트 결과 요약
- 별도의 자동화 테스트를 실행하지 못했어요.

## 보안·성능 고려사항
- UI 마크업 변경만 진행했고 추가적인 보안/성능 영향은 없어요.

## 관련 이슈 번호
- 해당 사항 없어요.


------
https://chatgpt.com/codex/tasks/task_e_68e3433c93c88323b3350eee653cbd03