### PR TITLE
[docs] tvb-ai 파이프라인 부재 현황을 정리했어요

### DIFF
--- a/docs/tvb-ai-pipeline-overview.md
+++ b/docs/tvb-ai-pipeline-overview.md
@@ -1,0 +1,59 @@
+# Gravifox AI Training & Inference Pipeline Status
+
+## 1. Repository Layout
+- The requested `tvb-ai/` workspace (containing `core/`, `scripts/`, etc.) is not present in the current checkout, so the training code, dataset builders, and optimizer modules cannot be inspected directly.  (See command trace below in this document for reproducibility.)
+- Because the source tree is missing, only the web frontend and the bundled FastAPI OpenAPI schema are available locally.
+
+## 2. FastAPI Surface (from `public/swagger.json`)
+- `/api/v1/images/{uuid}/analyze` – sends an uploaded image to the AI service and returns the prediction payload.
+- `/api/v1/images/send_data` – uploads an image for later analysis via UUID hand-off.
+- `/api/v1/files/upload` – generic file uploader, likely returning UUID references consumed by the analyzer.
+- `/api/v1/register`, `/api/v1/auth/login`, `/api/v1/auth/logout`, `/api/v1/auth/refresh`, `/api/v1/auth/me` – identity endpoints supporting the dashboard.
+- `/api/v1/profile/` and `/api/v1/issue/` – profile and issue tracker integration hooks for the console.
+- `/health` – service liveness probe.
+
+### Current Runtime Flow (observable portion)
+```text
+[Browser Upload]
+     |
+     v
+/api/v1/files/upload  -->  UUID ticket
+     |
+     v
+/api/v1/images/send_data (stores payload for inference)
+     |
+     v
+/api/v1/images/{uuid}/analyze  -->  { predicted_class, predicted_probability, prediction_time }
+```
+
+## 3. Missing Training Stack
+- Expected folders (based on the product brief):
+  ```
+  tvb-ai/
+    core/
+      configs/
+      datasets/
+      models/
+      trainer/
+      utils/
+    scripts/
+      train.py
+      launch_vit_residual_matrix.py
+  ```
+- None of these assets ship with this repository snapshot. Without them we cannot enumerate supported backbones, residual/multi-patch logic, dataset transforms, or optimizer policies.
+
+## 4. Known Gaps & Next Actions
+- Pull the missing `tvb-ai/` module (likely a submodule or private repository) to unlock the training and inference internals.
+- Once the sources are available, document:
+  - Backbone registry and configuration schema.
+  - Dataset/augmentation contracts for image vs. video inputs.
+  - Training orchestration (`train.py`, `optim.py`, schedulers, logging).
+  - Experiment launch scripts (`launch_vit_residual_matrix.py`) and YAML-driven sweeps.
+- Re-run this documentation effort after syncing the AI workspace to produce the full pipeline overview.
+
+---
+
+### Command trace (absence verification)
+```
+find . -maxdepth 4 -type d -name 'tvb-ai'
+```


### PR DESCRIPTION
## 변경 목적
- 현재 리포지토리에 `tvb-ai/` 학습 파이프라인이 없어서 분석을 진행할 수 없는 상황을 명시했어요.

## 주요 변경점
- FastAPI 스키마로 확인 가능한 엔드포인트와 현재 파이프라인 흐름을 문서화했어요.
- 누락된 학습 코드 구조와 후속 작업 항목을 정리했어요.

## 테스트 결과 요약
- 테스트를 실행하지 않았어요 (문서만 추가했어요).

## 보안·성능 고려사항
- 새로운 코드는 추가하지 않아서 보안/성능 영향이 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e4b4ee8f6083239c8222bb39b0ee75