### PR TITLE
[refactor] 모바일 분석 업로드 안내를 정리했어요

### DIFF
--- a/src/features/analyze/constants.js
+++ b/src/features/analyze/constants.js
@@ -1,0 +1,22 @@
+export const GUEST_DAILY_QUOTA = 10;
+export const DEFAULT_MEMBER_DAILY_QUOTA = 20;
+
+export const MAX_IMAGE_FILES = 3;
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // 5MB
+
+export const SUPPORTED_IMAGE_MIME_TYPES = Object.freeze([
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+export const SUPPORTED_IMAGE_EXTENSIONS = Object.freeze([
+  'jpeg',
+  'jpg',
+  'png',
+  'webp',
+]);
+
+export const SUPPORTED_IMAGE_EXTENSIONS_LABEL = SUPPORTED_IMAGE_EXTENSIONS.map((ext) =>
+  ext.toUpperCase()
+).join(', ');

--- a/src/hooks/useNumberFormatter.js
+++ b/src/hooks/useNumberFormatter.js
@@ -1,0 +1,8 @@
+import { useMemo } from 'react';
+
+export function useNumberFormatter(locale, options) {
+  const optionsKey = options ? JSON.stringify(options) : null;
+  return useMemo(() => new Intl.NumberFormat(locale || 'en', options), [locale, optionsKey]);
+}
+
+export default useNumberFormatter;

--- a/src/pages/MobileAnalyzeStart.js
+++ b/src/pages/MobileAnalyzeStart.js
@@ -1,10 +1,16 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
 import { UploadCloud, ShieldCheck, Clapperboard, LifeBuoy } from 'lucide-react';
 import Navigation from '../features/navigation/navigation';
 import Footer from '../features/footer/footer';
 import { useAuth } from 'providers/authProvider';
+import useNumberFormatter from '../hooks/useNumberFormatter';
+import {
+  DEFAULT_MEMBER_DAILY_QUOTA,
+  GUEST_DAILY_QUOTA,
+  MAX_IMAGE_FILES,
+} from '../features/analyze/constants';
 
 export default function MobileAnalyzeStart() {
   const { t, i18n } = useTranslation('common');
@@ -12,13 +18,10 @@ export default function MobileAnalyzeStart() {
   const { lng } = useParams();
   const { userInfo } = useAuth();
 
-  const formatNumber = useMemo(
-    () => new Intl.NumberFormat(i18n.language || 'en'),
-    [i18n.language]
-  );
+  const formatNumber = useNumberFormatter(i18n.language);
 
-  const guestDailyQuota = 10;
-  const memberDailyQuota = userInfo?.dailyQuota ?? 20;
+  const guestDailyQuota = GUEST_DAILY_QUOTA;
+  const memberDailyQuota = userInfo?.dailyQuota ?? DEFAULT_MEMBER_DAILY_QUOTA;
   const totalQuota = userInfo ? memberDailyQuota : guestDailyQuota;
   const usedToday = userInfo?.todayAnalyzeCount ?? 0;
   const remainingSessions = Math.max(totalQuota - usedToday, 0);
@@ -27,12 +30,40 @@ export default function MobileAnalyzeStart() {
   const formattedUpgrade = formatNumber.format(memberDailyQuota);
   const isLoggedIn = Boolean(userInfo);
 
-  const uploadRoute = lng ? `/${lng}/analyze/upload` : '/analyze/upload';
-  const supportRoute = lng ? `/${lng}/support` : '/support';
+  const uploadRoute = useMemo(
+    () => (lng ? `/${lng}/analyze/upload` : '/analyze/upload'),
+    [lng]
+  );
+  const supportRoute = useMemo(
+    () => (lng ? `/${lng}/support` : '/support'),
+    [lng]
+  );
 
-  const handleStart = () => {
+  const handleStart = useCallback(() => {
     navigate(uploadRoute);
-  };
+  }, [navigate, uploadRoute]);
+
+  const handleSampleStart = useCallback(() => {
+    navigate(uploadRoute, { state: { sample: true } });
+  }, [navigate, uploadRoute]);
+
+  const handleSupport = useCallback(() => {
+    navigate(supportRoute);
+  }, [navigate, supportRoute]);
+
+  const guidanceMessages = useMemo(
+    () => [
+      t(
+        'mobileAnalyze.guidance',
+        'Stuck between real or AI-made? Drop those tricky files here.'
+      ),
+      t(
+        'mobileAnalyze.guidance2',
+        'Stuck between real or AI-made? Drop those tricky files here.'
+      ),
+    ],
+    [t]
+  );
 
   // const handleHistory = () => {
   //   if (lng) {
@@ -55,16 +86,21 @@ export default function MobileAnalyzeStart() {
               <p className="mt-2 text-sm text-slate-400">
                 {t(
                   'mobileAnalyze.subheading',
-                  'Upload up to 5 images. We detect synthetic traces in seconds.'
+                  'Upload up to {{count}} images. We detect synthetic traces in seconds.',
+                  { count: MAX_IMAGE_FILES }
                 )}
               </p>
 
-              <p className="mt-3 border-l-2 border-indigo-500/40 pl-3 text-xs text-slate-400">
-                {t('mobileAnalyze.guidance', 'Stuck between real or AI-made? Drop those tricky files here.')}
-              </p>
-              <p className="mt-0.5 border-l-2 border-indigo-500/40 pl-3 text-xs text-slate-400">
-                {t('mobileAnalyze.guidance2', 'Stuck between real or AI-made? Drop those tricky files here.')}
-              </p>
+              {guidanceMessages.map((message, index) => (
+                <p
+                  key={index}
+                  className={`border-l-2 border-indigo-500/40 pl-3 text-xs text-slate-400 ${
+                    index === 0 ? 'mt-3' : 'mt-0.5'
+                  }`}
+                >
+                  {message}
+                </p>
+              ))}
             </div>
           </header>
 
@@ -131,7 +167,7 @@ export default function MobileAnalyzeStart() {
 
                 <button
                   type="button"
-                  onClick={() => navigate(uploadRoute, { state: { sample: true } })}
+                  onClick={handleSampleStart}
                   className="flex items-center justify-between gap-3 rounded-2xl border border-indigo-400/40 bg-indigo-500/15 px-3 py-3 text-indigo-100 transition hover:border-indigo-300 hover:bg-indigo-500/25"
                 >
                   <span className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-indigo-500/25 text-white">
@@ -173,7 +209,7 @@ export default function MobileAnalyzeStart() {
 
             <button
               type="button"
-              onClick={() => navigate(supportRoute)}
+              onClick={handleSupport}
               className="flex w-full items-center gap-3 rounded-[26px] border border-indigo-400/35 bg-indigo-500/12 px-4 py-4 text-left text-[12px] text-slate-100 shadow-[0_20px_40px_-28px_rgba(79,70,229,0.55)] transition hover:border-indigo-300/60 hover:bg-indigo-500/20"
             >
               <div className="flex items-center gap-3 flex-1 min-w-0">

--- a/src/pages/MobileAnalyzeUpload.js
+++ b/src/pages/MobileAnalyzeUpload.js
@@ -7,12 +7,18 @@ import Footer from '../features/footer/footer';
 import ErrorModal from '../features/analyze/components/ErrorModal';
 import { ANALYZE_MODEL_ENDPOINTS } from '../api/endPointRoute';
 import submitAnalyzeFiles from '../features/analyze/api/submitAnalyze';
+import {
+  MAX_IMAGE_FILES,
+  MAX_IMAGE_SIZE_BYTES,
+  SUPPORTED_IMAGE_EXTENSIONS,
+  SUPPORTED_IMAGE_EXTENSIONS_LABEL,
+  SUPPORTED_IMAGE_MIME_TYPES,
+} from '../features/analyze/constants';
 
-const MAX_IMAGE_FILES = 3;
-const MAX_IMAGE_SIZE = 5 * 1024 * 1024; // 5MB
+const MAX_IMAGE_SIZE_MB = Math.floor(MAX_IMAGE_SIZE_BYTES / (1024 * 1024));
 
-const IMAGE_MIMES = new Set(['image/jpeg', 'image/png', 'image/webp']);
-const IMAGE_EXTS = new Set(['jpeg', 'jpg', 'png', 'webp']);
+const IMAGE_MIMES = new Set(SUPPORTED_IMAGE_MIME_TYPES);
+const IMAGE_EXTS = new Set(SUPPORTED_IMAGE_EXTENSIONS);
 
 const getExt = (file) => {
   const name = (file?.name || '').toLowerCase();
@@ -165,7 +171,7 @@ export default function MobileAnalyzeUpload() {
         continue;
       }
 
-      if (file.size > MAX_IMAGE_SIZE) {
+      if (file.size > MAX_IMAGE_SIZE_BYTES) {
         oversizeFound = true;
         continue;
       }
@@ -193,11 +199,17 @@ export default function MobileAnalyzeUpload() {
     const msgs = [];
     if (invalidTypeFound) {
       msgs.push(t('mobileAnalyze.uploadPage.errors.type', '지원하지 않는 파일 형식이에요.'));
-      msgs.push('JPEG, JPG, PNG, WEBP');
+      msgs.push(SUPPORTED_IMAGE_EXTENSIONS_LABEL);
     }
     if (oversizeFound) {
       msgs.push(t('mobileAnalyze.uploadPage.errors.size', '파일 용량 제한을 초과했어요.'));
-      msgs.push(t('mobileAnalyze.uploadPage.errors.sizeHint', '이미지는 최대 5MB까지만 업로드할 수 있어요.'));
+      msgs.push(
+        t(
+          'mobileAnalyze.uploadPage.errors.sizeHint',
+          '이미지는 최대 {{max}}MB까지만 업로드할 수 있어요.',
+          { max: MAX_IMAGE_SIZE_MB }
+        )
+      );
     }
     if (dupMsgs.length > 0) {
       msgs.push(...dupMsgs);


### PR DESCRIPTION
## 변경 목적
- 스타트 화면과 업로드 화면에서 업로드 제한과 세션 안내를 일관되게 보여주도록 정리했어요.

## 주요 변경점
- 업로드 제한과 일일 할당량 상수를 `features/analyze/constants.js`로 분리했어요.
- 숫자 포맷터 훅을 만들어 `/analyze` 시작 화면에서 재사용했어요.
- 스타트 화면의 가이드 문구와 네비게이션 핸들러를 정리했어요.
- 업로드 화면에서 상수를 공용 값으로 교체하고 안내 문구를 동기화했어요.

## 테스트 결과 요약
- `npm run lint` (스크립트가 없어서 실행에 실패했어요)

## 보안·성능 고려사항
- 별도 영향 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68e9110c301c8323b3e0a33f2fbf2050