### PR TITLE
[feat] 업로드 미디어 미리보기 유지했어요

### DIFF
--- a/src/features/analyze/api/submitAnalyze.js
+++ b/src/features/analyze/api/submitAnalyze.js
@@ -127,8 +127,13 @@ export async function submitAnalyzeFiles(files, {
                 };
                 if (typeof buildMeta === "function") {
                     try {
-                        const extraMeta = buildMeta(file, analyzeJson) || {};
-                        Object.assign(baseMeta, extraMeta);
+                        const extraMetaMaybe = buildMeta(file, analyzeJson);
+                        const extraMeta = extraMetaMaybe && typeof extraMetaMaybe.then === "function"
+                            ? await extraMetaMaybe
+                            : extraMetaMaybe;
+                        if (extraMeta && typeof extraMeta === "object") {
+                            Object.assign(baseMeta, extraMeta);
+                        }
                     } catch {}
                 }
                 sessionStorage.setItem(`sse:meta:${jobId}`, JSON.stringify(baseMeta));

--- a/src/features/analyze/components/mobile/MobileAnalysisReport.jsx
+++ b/src/features/analyze/components/mobile/MobileAnalysisReport.jsx
@@ -86,6 +86,7 @@ export default function MobileAnalysisReport({ jobId, report, t }) {
 
   const fileName = report?.fileMeta?.name || '';
   const modelKey = report?.fileMeta?.modelKey || '';
+  const filePreview = typeof report?.fileMeta?.previewDataUrl === 'string' ? report.fileMeta.previewDataUrl : null;
   const shortId = jobId.slice(-6);
 
   const probFake =
@@ -277,6 +278,22 @@ export default function MobileAnalysisReport({ jobId, report, t }) {
             <ScoreDial value={confidenceValue} label={confidenceLabel} theme={theme} />
           </div>
         </div>
+
+        {filePreview && (
+          <div className="rounded-3xl border border-white/12 bg-black/25 p-4">
+            <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-200/80">
+              {t?.('mobileAnalyze.report.previewUpload', '업로드 미디어 미리보기')}
+            </div>
+            <div className="mt-3 overflow-hidden rounded-2xl border border-white/10 bg-slate-900/40">
+              <img
+                src={filePreview}
+                alt={fileName ? `${fileName} 미리보기` : t?.('mobileAnalyze.report.previewUploadAlt', '업로드한 미디어 미리보기')}
+                className="h-full w-full object-contain bg-slate-950/50"
+                loading="lazy"
+              />
+            </div>
+          </div>
+        )}
 
         {metrics.length > 0 && (
           <div className="grid grid-cols-1 gap-3 min-[430px]:grid-cols-2">

--- a/src/features/analyze/components/report/AnalysisReport.jsx
+++ b/src/features/analyze/components/report/AnalysisReport.jsx
@@ -274,18 +274,30 @@ const AnalysisReport = forwardRef(function AnalysisReport({ data, mediaMeta }, r
 
         {mediaMeta && (
           <div className="mt-4 rounded-xl border border-slate-200 p-4">
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              <div>
-                <p className="text-xs text-slate-500">파일명</p>
-                <p className="truncate text-sm font-medium text-slate-800">{mediaMeta?.name || '-'}</p>
-              </div>
-              <div>
-                <p className="text-xs text-slate-500">타입</p>
-                <p className="text-sm font-medium text-slate-800">{mediaMeta?.type || '-'}</p>
-              </div>
-              <div>
-                <p className="text-xs text-slate-500">크기</p>
-                <p className="text-sm font-medium text-slate-800">{prettyBytes(mediaMeta?.size)}</p>
+            <div className="flex flex-col gap-4 sm:flex-row">
+              {mediaMeta?.previewDataUrl && (
+                <div className="w-full max-w-[220px] overflow-hidden rounded-lg border border-slate-200 bg-slate-50">
+                  <img
+                    src={mediaMeta.previewDataUrl}
+                    alt={mediaMeta?.name ? `${mediaMeta.name} 미리보기` : '업로드한 미디어 미리보기'}
+                    className="block h-full w-full object-contain bg-white"
+                    loading="lazy"
+                  />
+                </div>
+              )}
+              <div className="grid flex-1 grid-cols-1 gap-3 sm:grid-cols-3">
+                <div>
+                  <p className="text-xs text-slate-500">파일명</p>
+                  <p className="truncate text-sm font-medium text-slate-800">{mediaMeta?.name || '-'}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">타입</p>
+                  <p className="text-sm font-medium text-slate-800">{mediaMeta?.type || '-'}</p>
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500">크기</p>
+                  <p className="text-sm font-medium text-slate-800">{prettyBytes(mediaMeta?.size)}</p>
+                </div>
               </div>
             </div>
           </div>

--- a/src/features/analyze/components/upload/UploadPanel.jsx
+++ b/src/features/analyze/components/upload/UploadPanel.jsx
@@ -9,6 +9,7 @@ import FilePreviewCard from "./FilePreviewCard";
 import MobileFilePreviewItem from "../mobile/MobileFilePreviewItem";
 import UploadMoreNote from "./UploadMoreNote";
 import ErrorModal from "../ErrorModal";
+import { readFileAsDataURL } from "../../../../utils/filePreview";
 
 const MAX_IMAGE_FILES = 3;
 const MAX_VIDEO_FILES = 2;
@@ -181,11 +182,18 @@ export default function UploadPanel({
         try {
             const { jobIds, errors: uploadErrors, remainingQuota } = await submitAnalyzeFiles(arr, {
                 modelKey: selectedModelKey,
-                buildMeta: (file) => ({
-                    name: file?.name,
-                    size: file?.size,
-                    type: file?.type,
-                }),
+                buildMeta: async (file) => {
+                    const base = {
+                        name: file?.name,
+                        size: file?.size,
+                        type: file?.type,
+                    };
+                    const preview = await readFileAsDataURL(file);
+                    if (preview) {
+                        base.previewDataUrl = preview;
+                    }
+                    return base;
+                },
             });
 
             if (!jobIds.length) {

--- a/src/features/dashboard/components/AnalysisHistoryList.jsx
+++ b/src/features/dashboard/components/AnalysisHistoryList.jsx
@@ -4,6 +4,7 @@ import { ANALYZE_ENDPOINTS, FASTAPI_ENDPOINTS } from "../../../api/endPointRoute
 import axios from "../../../api/http";
 import ensureUploadToken from "../../analyze/api/uploadTokenClient";
 import { Transition } from '@headlessui/react';
+import { buildStoredFailure, buildStoredReport, parseStoredReport } from "../../../utils/reportStorage";
 
 function readLocalReports() {
   try {
@@ -14,15 +15,16 @@ function readLocalReports() {
       const jobId = key.replace("sse:report:", "");
       try {
         const raw = sessionStorage.getItem(key);
-        const data = raw ? JSON.parse(raw) : null;
-        // try to attach file meta
-        let meta = null;
-        try {
-          const m = sessionStorage.getItem(`sse:meta:${jobId}`);
-          meta = m ? JSON.parse(m) : null;
-        } catch {}
-        if (data && jobId) {
-          items.push({ jobId, data, meta });
+        const stored = parseStoredReport(raw);
+        let meta = stored.fileMeta;
+        if (!meta) {
+          try {
+            const m = sessionStorage.getItem(`sse:meta:${jobId}`);
+            meta = m ? JSON.parse(m) : null;
+          } catch {}
+        }
+        if (stored.result && jobId) {
+          items.push({ jobId, data: stored.result, meta, storedAt: stored.storedAt || null });
         }
       } catch {}
     }
@@ -616,7 +618,7 @@ function ReAnalyzePane({ onFinish }) {
           const d = JSON.parse(e.data || '{}');
           const payload = (d.result || d);
           setResult(payload);
-          try { sessionStorage.setItem(`sse:report:${jobId}`, JSON.stringify(payload)); } catch {}
+          try { sessionStorage.setItem(`sse:report:${jobId}`, JSON.stringify(buildStoredReport(payload, fileMeta))); } catch {}
         } catch {}
         try { es.close(); } catch {}
         setSubmitting(false);
@@ -627,7 +629,7 @@ function ReAnalyzePane({ onFinish }) {
           const d = JSON.parse(e.data || '{}');
           const reason = (d?.reason || '분석에 실패했어요.');
           setError(reason);
-          try { sessionStorage.setItem(`sse:failed:${jobId}`, reason); } catch {}
+          try { sessionStorage.setItem(`sse:failed:${jobId}`, JSON.stringify(buildStoredFailure(reason, fileMeta))); } catch {}
         } catch { setError('분석에 실패했어요.'); }
         try { es.close(); } catch {}
         setSubmitting(false);

--- a/src/features/dashboard/components/StatsSummaryBar.jsx
+++ b/src/features/dashboard/components/StatsSummaryBar.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo } from "react";
+import { parseStoredReport } from "../../../utils/reportStorage";
 
 function readLocalReports() {
   try {
@@ -9,10 +10,12 @@ function readLocalReports() {
       const jobId = key.replace("sse:report:", "");
       try {
         const raw = sessionStorage.getItem(key);
-        const data = raw ? JSON.parse(raw) : null;
-        let meta = null;
-        try { const m = sessionStorage.getItem(`sse:meta:${jobId}`); meta = m ? JSON.parse(m) : null; } catch {}
-        if (data && jobId) items.push({ jobId, data, meta });
+        const stored = parseStoredReport(raw);
+        let meta = stored.fileMeta;
+        if (!meta) {
+          try { const m = sessionStorage.getItem(`sse:meta:${jobId}`); meta = m ? JSON.parse(m) : null; } catch {}
+        }
+        if (stored.result && jobId) items.push({ jobId, data: stored.result, meta, storedAt: stored.storedAt || null });
       } catch {}
     }
     return items;

--- a/src/pages/AnalyzeResult.js
+++ b/src/pages/AnalyzeResult.js
@@ -5,6 +5,7 @@ import Footer from "../features/footer/footer";
 import AnalysisReport from "../features/analyze/components/report/AnalysisReport";
 import { ANALYZE_ENDPOINTS } from "../api/endPointRoute";
 import { normalizeAnalysisResult } from "../features/analyze/utils/normalizeResult";
+import { buildStoredFailure, buildStoredReport, parseStoredFailure, parseStoredReport } from "../utils/reportStorage";
 
 // 로딩 멘트(랜덤 회전). 스테이지에 맞춘 후보 포함
 const LOADING_MENTS = {
@@ -151,15 +152,18 @@ export default function AnalyzeResult() {
 
       if (!token) {
         // 토큰이 없어도, 저장된 결과/실패 정보가 있으면 복원해서 표시
-        const savedResult = (() => { try { return JSON.parse(sessionStorage.getItem(`sse:report:${jid}`) || 'null'); } catch { return null; } })();
-        const savedFailed = sessionStorage.getItem(`sse:failed:${jid}`);
-        if (savedResult) {
-          const normalized = normalizeAnalysisResult(savedResult);
-          setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), result: normalized, connected: false, fileMeta } }));
+        const storedReportRaw = sessionStorage.getItem(`sse:report:${jid}`);
+        const { result: storedResult, fileMeta: storedMeta } = parseStoredReport(storedReportRaw, fileMeta);
+        const effectiveMeta = storedMeta || fileMeta;
+        if (storedResult) {
+          const normalized = normalizeAnalysisResult(storedResult);
+          setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), result: normalized, connected: false, fileMeta: effectiveMeta } }));
           return;
         }
-        if (savedFailed) {
-          setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), error: savedFailed || '분석에 실패했어요.', connected: false, fileMeta } }));
+        const storedFailedRaw = sessionStorage.getItem(`sse:failed:${jid}`);
+        const { reason: storedReason, fileMeta: failedMeta } = parseStoredFailure(storedFailedRaw, effectiveMeta);
+        if (storedReason) {
+          setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), error: storedReason || '분석에 실패했어요.', connected: false, fileMeta: failedMeta || effectiveMeta } }));
           return;
         }
         setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), error: '세션 토큰을 찾을 수 없어요. 다시 시작해 주세요.', connected: false, fileMeta } }));
@@ -182,7 +186,7 @@ export default function AnalyzeResult() {
           const d = JSON.parse(e.data || '{}');
           const payload = normalizeAnalysisResult(d.result || d);
           setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), result: payload, fileMeta } }));
-          try { sessionStorage.setItem(`sse:report:${jid}`, JSON.stringify(payload)); } catch {}
+          try { sessionStorage.setItem(`sse:report:${jid}`, JSON.stringify(buildStoredReport(payload, fileMeta))); } catch {}
         } catch {}
         es.close();
         try { sessionStorage.removeItem(`sse:${jid}`); sessionStorage.removeItem(`sse:meta:${jid}`); } catch {}
@@ -192,7 +196,7 @@ export default function AnalyzeResult() {
           const d = JSON.parse(e.data || '{}');
           const reason = (d?.reason || '분석에 실패했어요.');
           setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), error: reason, fileMeta } }));
-          try { sessionStorage.setItem(`sse:failed:${jid}`, reason); } catch {}
+          try { sessionStorage.setItem(`sse:failed:${jid}`, JSON.stringify(buildStoredFailure(reason, fileMeta))); } catch {}
         } catch {
           setReports(prev => ({ ...prev, [jid]: { ...(prev[jid] || {}), error: '분석에 실패했어요.', fileMeta } }));
         }

--- a/src/pages/MobileAnalyzeResult.js
+++ b/src/pages/MobileAnalyzeResult.js
@@ -7,6 +7,7 @@ import Footer from '../features/footer/footer';
 import { ANALYZE_ENDPOINTS } from '../api/endPointRoute';
 import MobileAnalysisReport from '../features/analyze/components/mobile/MobileAnalysisReport';
 import { normalizeAnalysisResult } from '../features/analyze/utils/normalizeResult';
+import { buildStoredFailure, buildStoredReport, parseStoredFailure, parseStoredReport } from '../utils/reportStorage';
 
 const IS_TEST_ENV = String(process.env.NODE_ENV || '').toLowerCase() === 'test';
 const TEST_TIMEOUT_MS = 10_000;
@@ -133,33 +134,32 @@ export default function MobileAnalyzeResult() {
       }));
 
       if (!token) {
-        const savedResult = (() => {
-          try {
-            return JSON.parse(sessionStorage.getItem(`sse:report:${jid}`) || 'null');
-          } catch {
-            return null;
-          }
-        })();
-        const savedFailed = sessionStorage.getItem(`sse:failed:${jid}`);
-        if (savedResult) {
-          const normalized = normalizeAnalysisResult(savedResult);
+        const storedReportRaw = sessionStorage.getItem(`sse:report:${jid}`);
+        const { result: storedResult, fileMeta: storedMeta } = parseStoredReport(storedReportRaw, fileMeta);
+        const effectiveMeta = storedMeta || fileMeta;
+        if (storedResult) {
+          const normalized = normalizeAnalysisResult(storedResult);
           setReports((prev) => ({
             ...prev,
             [jid]: {
               ...(prev[jid] || {}),
               result: normalized,
-              fileMeta,
+              fileMeta: effectiveMeta,
             },
           }));
-        } else if (savedFailed) {
-          setReports((prev) => ({
-            ...prev,
-            [jid]: {
-              ...(prev[jid] || {}),
-              error: savedFailed,
-              fileMeta,
-            },
-          }));
+        } else {
+          const storedFailedRaw = sessionStorage.getItem(`sse:failed:${jid}`);
+          const { reason: storedReason, fileMeta: failedMeta } = parseStoredFailure(storedFailedRaw, effectiveMeta);
+          if (storedReason) {
+            setReports((prev) => ({
+              ...prev,
+              [jid]: {
+                ...(prev[jid] || {}),
+                error: storedReason,
+                fileMeta: failedMeta || effectiveMeta,
+              },
+            }));
+          }
         }
         return;
       }
@@ -239,7 +239,7 @@ export default function MobileAnalyzeResult() {
             },
           }));
           try {
-            sessionStorage.setItem(`sse:report:${jid}`, JSON.stringify(payload));
+            sessionStorage.setItem(`sse:report:${jid}`, JSON.stringify(buildStoredReport(payload, fileMeta)));
           } catch {}
         } catch {}
         if (timeoutId) clearTimeout(timeoutId);
@@ -263,7 +263,7 @@ export default function MobileAnalyzeResult() {
             },
           }));
           try {
-            sessionStorage.setItem(`sse:failed:${jid}`, reason);
+            sessionStorage.setItem(`sse:failed:${jid}`, JSON.stringify(buildStoredFailure(reason, fileMeta)));
           } catch {}
         } catch {
           setReports((prev) => ({

--- a/src/pages/MobileAnalyzeUpload.js
+++ b/src/pages/MobileAnalyzeUpload.js
@@ -10,6 +10,7 @@ import submitAnalyzeFiles from '../features/analyze/api/submitAnalyze';
 import { fetchQuotaSummary } from '../features/analyze/api/quotaSummary';
 import LoginRequiredModal from '../features/analyze/components/LoginRequiredModal';
 import { useAuth } from 'providers/authProvider';
+import { readFileAsDataURL } from '../utils/filePreview';
 import {
   rememberReturnCheckpoint,
   clearReturnCheckpoint,
@@ -428,12 +429,19 @@ export default function MobileAnalyzeUpload() {
     try {
       const { jobIds, errors, remainingQuota } = await submitAnalyzeFiles(files, {
         modelKey,
-        buildMeta: (file) => ({
-          name: file?.name,
-          size: file?.size,
-          type: file?.type,
-          modelKey,
-        }),
+        buildMeta: async (file) => {
+          const base = {
+            name: file?.name,
+            size: file?.size,
+            type: file?.type,
+            modelKey,
+          };
+          const preview = await readFileAsDataURL(file);
+          if (preview) {
+            base.previewDataUrl = preview;
+          }
+          return base;
+        },
       });
 
       if (typeof remainingQuota === 'number') {

--- a/src/utils/filePreview.js
+++ b/src/utils/filePreview.js
@@ -1,0 +1,24 @@
+export function isPreviewableImage(file) {
+  if (!file) return false;
+  const type = typeof file?.type === 'string' ? file.type : '';
+  if (type) return type.startsWith('image/');
+  const name = typeof file?.name === 'string' ? file.name.toLowerCase() : '';
+  return ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.heic', '.heif'].some((ext) => name.endsWith(ext));
+}
+
+export function readFileAsDataURL(file, { sizeLimit = 5 * 1024 * 1024 } = {}) {
+  if (!isPreviewableImage(file)) return Promise.resolve(null);
+  if (typeof file?.size === 'number' && sizeLimit && file.size > sizeLimit) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    try {
+      const reader = new FileReader();
+      reader.onload = () => {
+        resolve(typeof reader.result === 'string' ? reader.result : null);
+      };
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(file);
+    } catch {
+      resolve(null);
+    }
+  });
+}

--- a/src/utils/reportStorage.js
+++ b/src/utils/reportStorage.js
@@ -1,0 +1,79 @@
+export function buildStoredReport(result, fileMeta) {
+  return {
+    version: 2,
+    storedAt: Date.now(),
+    result: result ?? null,
+    fileMeta: fileMeta ?? null,
+  };
+}
+
+export function buildStoredFailure(reason, fileMeta) {
+  return {
+    version: 2,
+    storedAt: Date.now(),
+    reason: reason ?? null,
+    fileMeta: fileMeta ?? null,
+  };
+}
+
+export function parseStoredReport(rawValue, fallbackMeta = null) {
+  if (!rawValue) {
+    return { result: null, fileMeta: fallbackMeta, storedAt: null, version: 0 };
+  }
+  try {
+    const parsed = typeof rawValue === 'string' ? JSON.parse(rawValue) : rawValue;
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const hasStructured = 'result' in parsed || 'fileMeta' in parsed || 'data' in parsed || 'meta' in parsed;
+      const result = 'result' in parsed ? parsed.result : 'data' in parsed ? parsed.data : hasStructured ? null : parsed;
+      const fileMeta = parsed.fileMeta ?? parsed.meta ?? fallbackMeta ?? null;
+      const storedAt = typeof parsed.storedAt === 'number' ? parsed.storedAt : null;
+      const version = typeof parsed.version === 'number' ? parsed.version : hasStructured ? 2 : 1;
+      return {
+        result: result ?? (hasStructured ? null : parsed),
+        fileMeta,
+        storedAt,
+        version,
+      };
+    }
+    return { result: parsed ?? null, fileMeta: fallbackMeta, storedAt: null, version: 1 };
+  } catch {
+    return { result: null, fileMeta: fallbackMeta, storedAt: null, version: 0 };
+  }
+}
+
+export function parseStoredFailure(rawValue, fallbackMeta = null) {
+  if (!rawValue) {
+    return { reason: null, fileMeta: fallbackMeta, storedAt: null, version: 0 };
+  }
+  if (typeof rawValue === 'string') {
+    try {
+      const parsed = JSON.parse(rawValue);
+      if (typeof parsed === 'string') {
+        return { reason: parsed, fileMeta: fallbackMeta, storedAt: null, version: 1 };
+      }
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const reason = parsed.reason ?? parsed.message ?? null;
+        const fileMeta = parsed.fileMeta ?? parsed.meta ?? fallbackMeta ?? null;
+        const storedAt = typeof parsed.storedAt === 'number' ? parsed.storedAt : null;
+        const version = typeof parsed.version === 'number' ? parsed.version : 2;
+        return {
+          reason: reason ?? null,
+          fileMeta,
+          storedAt,
+          version,
+        };
+      }
+      return { reason: parsed != null ? String(parsed) : null, fileMeta: fallbackMeta, storedAt: null, version: 1 };
+    } catch {
+      return { reason: rawValue, fileMeta: fallbackMeta, storedAt: null, version: 1 };
+    }
+  }
+  if (rawValue && typeof rawValue === 'object') {
+    const reason = rawValue.reason ?? rawValue.message ?? null;
+    const fileMeta = rawValue.fileMeta ?? rawValue.meta ?? fallbackMeta ?? null;
+    const storedAt = typeof rawValue.storedAt === 'number' ? rawValue.storedAt : null;
+    const version = typeof rawValue.version === 'number' ? rawValue.version : 2;
+    return { reason, fileMeta, storedAt, version };
+  }
+  return { reason: String(rawValue), fileMeta: fallbackMeta, storedAt: null, version: 1 };
+}


### PR DESCRIPTION
## 변경 목적
- 분석 결과 페이지에서 사용자가 업로드한 이미지를 새로고침하거나 나중에 다시 방문했을 때도 확인할 수 있도록 세션 저장 구조를 개선했어요.

## 주요 변경점
- 업로드 시 이미지 파일을 Data URL로 변환해 메타데이터와 함께 저장하도록 공통 유틸을 추가했어요.
- 분석 SSE 결과를 저장할 때 파일 메타데이터와 미리보기 정보를 함께 기록하고, 복원 시에도 이를 활용하도록 데스크톱/모바일 결과 페이지 로직을 수정했어요.
- 결과 화면 및 모바일 리포트에 업로드 미디어 미리보기 UI를 추가하고, 대시보드 요약/히스토리에서도 새로운 저장 구조를 읽도록 업데이트했어요.

## 테스트 결과 요약
- 테스트를 실행하지 않았어요.

## 보안·성능 고려사항
- 5MB 이하의 이미지에 대해서만 Data URL 미리보기를 세션 스토리지에 저장하도록 제한해 브라우저 메모리 사용을 완화했어요.

## 관련 이슈 번호
- 없어요.


------
https://chatgpt.com/codex/tasks/task_e_68eb5077bb4c8323a5862affbb084bf6