### PR TITLE
[feat] 분석 완료 카드 스타일을 개선했어요

### DIFF
--- a/src/features/freeTrial/components/resultAnalyze.js
+++ b/src/features/freeTrial/components/resultAnalyze.js
@@ -10,95 +10,121 @@ const ResultAnalyze = ({analyzeResult }) => {
     const durationGauge = Math.max(0, Math.min(100, duration)) * 3.75;
 
     return (
-        <div className="w-full ">
-            <div>
-                <div>
+        <div className="relative w-full">
+            <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-slate-900/40 text-slate-100 shadow-[0_25px_60px_-35px_rgba(15,23,42,0.9)]">
+                <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.25),_transparent_55%)]"/>
+                <div className="pointer-events-none absolute -inset-px rounded-3xl border border-white/5 mix-blend-overlay"/>
+                <div className="relative">
                     <button
                         type="button"
-                        className="flex items-center justify-between w-full text-left text-slate-900 transition duration-150 ease-in-out"
+                        className={`flex w-full items-center justify-between gap-6 rounded-3xl px-6 py-5 text-left transition-all duration-300 ease-out hover:bg-white/5 ${open ? "bg-white/10" : ""}`}
                         onClick={() => setOpen((v) => !v)}
                         aria-expanded={open}
                         aria-controls="accordion-panel"
                     >
-                        <p className="text-lg font-bold">This Picture is {analyzeResult.predicted_class}</p>
-                        <svg className={`fill-indigo-500 shrink-0 ml-8 w-4 h-4 transition-transform duration-200 ease-out ${open ? "rotate-180" : ""}`} width="16" height="16" xmlns="http://www.w3.org/2000/svg">
-                            <rect y="7" width="16" height="2" rx="1" className={`transform origin-center transition duration-200 ease-out ${open ? "rotate-180" : ""}`}></rect>
-                            <rect y="7" width="16" height="2" rx="1" className={`transform origin-center rotate-90 transition duration-200 ease-out ${open ? "rotate-180" : ""}`}></rect>
+                        <div className="flex flex-col gap-3">
+                            <span className="inline-flex w-fit items-center gap-2 rounded-full bg-white/10 px-3 py-1 text-xs font-medium uppercase tracking-widest text-indigo-200">
+                                <span className="size-1.5 rounded-full bg-emerald-400 shadow-[0_0_12px_rgba(74,222,128,0.8)]"/>
+                                분석 완료
+                            </span>
+                            <p className="text-xl font-semibold text-white">
+                                이 이미지는 <span className="bg-gradient-to-r from-indigo-300 via-sky-300 to-emerald-300 bg-clip-text text-transparent">{analyzeResult.predicted_class}</span>로 분류됐어요
+                            </p>
+                            <div className="h-0.5 w-16 rounded-full bg-gradient-to-r from-indigo-400 via-sky-400 to-emerald-400"/>
+                        </div>
+                        <svg
+                            className={`h-10 w-10 rounded-full border border-white/10 bg-white/5 p-3 text-indigo-200 transition-transform duration-300 ease-out ${open ? "rotate-180" : ""}`}
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path d="M12 7L17 12L12 17" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
+                            <path d="M7 12H17" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
                         </svg>
                     </button>
                 </div>
                 <div
                     id="accordion-panel"
-                    className={`overflow-hidden transition-all duration-300 ease-in-out ${open ? "max-h-96 opacity-100 py-5" : "max-h-0 opacity-0 py-0"}`}
+                    className={`relative overflow-hidden px-6 transition-all duration-500 ease-in-out ${open ? "max-h-[820px] py-8 opacity-100" : "max-h-0 py-0 opacity-0"}`}
                     aria-hidden={!open}
                 >
-                    <div className="flex flex-row items-center gap-10 my-3">
-                        {title.map((title, index) => (
-                            <p className="flex items-center text-gray-700 font-semibold">
-                                <svg xmlns="http://www.w3.org/2000/svg" className="mx-2 h-6 w-6 text-blue-500" fill="none"
-                                     viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                          d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
+                    <div className="relative mb-6 flex flex-wrap items-center gap-4">
+                        {title.map((item, index) => (
+                            <div key={`${item}-${index}`} className="group flex items-center gap-3 rounded-2xl border border-white/5 bg-white/5 px-4 py-2 text-sm font-semibold text-slate-100 backdrop-blur">
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    className="h-5 w-5 text-emerald-300 transition-transform duration-300 group-hover:scale-110"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="1.5" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"/>
                                 </svg>
-
-                                <span className="mx-2">{title}</span>
-                            </p>
+                                <span>{item}</span>
+                            </div>
                         ))}
                     </div>
 
-                    <div className="flex mx-auto items-center justify-center gap-10">
-                        <div className="relative size-40 mt-7">
-                            <svg className="rotate-[135deg] size-full" viewBox="0 0 36 36"
-                                 xmlns="http://www.w3.org/2000/svg">
-                                <circle cx="18" cy="18" r="16" fill="none" className="stroke-current text-green-200"
-                                        strokeWidth="1" stroke-dasharray="75 100" strokeLinecap="round"></circle>
-                                <circle
-                                    cx="18"
-                                    cy="18"
-                                    r="16"
-                                    fill="none"
-                                    className="stroke-current text-green-500"
-                                    strokeWidth="2"
-                                    strokeDasharray={`${gauge} 100`}
-                                    strokeLinecap="round"
-                                />
-                            </svg>
-                            <div
-                                className="absolute top-1/2 start-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center">
-                                <span className="text-4xl font-bold text-green-600">{score}</span>
-                                <span className="text-green-600 block">Score</span>
+                    <div className="grid gap-6 md:grid-cols-2">
+                        <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur">
+                            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-emerald-400/15 via-transparent to-transparent"/>
+                            <div className="relative flex flex-col items-center gap-4 text-center">
+                                <div className="relative size-40">
+                                    <svg className="size-full -rotate-45" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
+                                        <circle cx="18" cy="18" r="16" fill="none" className="stroke-current text-emerald-900/30" strokeWidth="1.5" strokeDasharray="75 100" strokeLinecap="round"/>
+                                        <circle
+                                            cx="18"
+                                            cy="18"
+                                            r="16"
+                                            fill="none"
+                                            className="stroke-current text-emerald-300"
+                                            strokeWidth="2.8"
+                                            strokeDasharray={`${gauge} 100`}
+                                            strokeLinecap="round"
+                                        />
+                                    </svg>
+                                    <div className="absolute inset-0 flex flex-col items-center justify-center">
+                                        <span className="text-4xl font-bold text-white">{score}</span>
+                                        <span className="text-sm uppercase tracking-[0.3em] text-emerald-200">Score</span>
+                                    </div>
+                                </div>
+                                <p className="text-sm leading-relaxed text-slate-200/80">AI가 이미지를 진짜라고 판단한 확률이에요. 수치가 높을수록 신뢰도가 높아요.</p>
                             </div>
                         </div>
 
-                        <div className="relative size-40 mt-7">
-                            <svg className="rotate-[135deg] size-full" viewBox="0 0 36 36"
-                                 xmlns="http://www.w3.org/2000/svg">
-                                <circle cx="18" cy="18" r="16" fill="none" className="stroke-current text-blue-200"
-                                        strokeWidth="1" stroke-dasharray="75 100" strokeLinecap="round"></circle>
-                                <circle
-                                    cx="18"
-                                    cy="18"
-                                    r="16"
-                                    fill="none"
-                                    className="stroke-current text-blue-500"
-                                    strokeWidth="2"
-                                    strokeDasharray={`${durationGauge} 100`}
-                                    strokeLinecap="round"
-                                />
-                            </svg>
-                            <div
-                                className="absolute top-1/2 start-1/2 transform -translate-x-1/2 -translate-y-1/2 text-center">
-                                <span className="text-4xl font-bold text-blue-600">{duration}</span>
-                                <span className="text-blue-600 block">Duration</span>
+                        <div className="relative overflow-hidden rounded-3xl border border-white/5 bg-white/5 p-6 backdrop-blur">
+                            <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-sky-400/15 via-transparent to-transparent"/>
+                            <div className="relative flex flex-col items-center gap-4 text-center">
+                                <div className="relative size-40">
+                                    <svg className="size-full -rotate-45" viewBox="0 0 36 36" xmlns="http://www.w3.org/2000/svg">
+                                        <circle cx="18" cy="18" r="16" fill="none" className="stroke-current text-sky-900/30" strokeWidth="1.5" strokeDasharray="75 100" strokeLinecap="round"/>
+                                        <circle
+                                            cx="18"
+                                            cy="18"
+                                            r="16"
+                                            fill="none"
+                                            className="stroke-current text-sky-300"
+                                            strokeWidth="2.8"
+                                            strokeDasharray={`${durationGauge} 100`}
+                                            strokeLinecap="round"
+                                        />
+                                    </svg>
+                                    <div className="absolute inset-0 flex flex-col items-center justify-center">
+                                        <span className="text-4xl font-bold text-white">{duration}</span>
+                                        <span className="text-sm uppercase tracking-[0.3em] text-sky-200">Duration</span>
+                                    </div>
+                                </div>
+                                <p className="text-sm leading-relaxed text-slate-200/80">예측을 완료하는 데 걸린 시간이예요. 짧을수록 처리 속도가 빠르다는 뜻이에요.</p>
                             </div>
                         </div>
                     </div>
-                    <p className="text-right p-2 mt-2 font-semibold">score : 인공지능이 진짜라고 생각한 점수 0~100 점 까지 있어요</p>
-                    <p className="text-right p-2 font-semibold">duration : 예측하는데 수행된 시간을 의미해요</p>
 
+                    <div className="mt-8 flex flex-col gap-2 text-right text-xs font-medium text-slate-300/90">
+                        <p>Score · 0~100 범위에서 AI가 진짜라고 판단한 확률이에요.</p>
+                        <p>Duration · 예측을 완료하기까지 소요된 시간이에요.</p>
+                    </div>
                 </div>
             </div>
-
         </div>
     );
 };


### PR DESCRIPTION
## 변경 목적
- 분석 완료 카드의 시각적 완성도를 높여 체험 사용자가 더 고급스러운 경험을 느끼도록 했어요.

## 주요 변경점
- 결과 카드 전체를 글래스모피즘 기반의 고급 테마로 재구성했어요.
- 분석 요약 배지와 그래디언트 타이포그래피, 하이라이트 라인을 추가해 헤더를 강조했어요.
- 점수와 소요 시간 지표를 각각 독립된 카드로 꾸미고 안내 문구를 보강했어요.

## 테스트 결과 요약
- `npm start`로 개발 서버를 실행해 수동으로 화면을 확인했어요. (기존 ESLint 경고가 함께 출력됐어요.)

## 보안·성능 고려사항
- 스타일 변경만 포함되어 있어 보안/성능 영향은 없어요.

## 관련 이슈 번호
- 없음

------
https://chatgpt.com/codex/tasks/task_e_68ebc47c12288323964cf2adeaed00bd