### PR TITLE
[feat] Analyze UI 테스트 모드를 추가했어요

### DIFF
--- a/docs/analyze-ui-test-guide.md
+++ b/docs/analyze-ui-test-guide.md
@@ -1,0 +1,37 @@
+# 모바일 분석 UI 테스트 가이드
+
+테스트 모드는 실서비스 API 호출 없이 업로드/결과 화면을 점검할 수 있도록 더미 데이터를 제공합니다. 아래 안내를 참고해 테스트 플로우를 구성하세요.
+
+## 테스트 모드 진입 방법
+
+1. 주소창에 `uiTest=1` 쿼리를 추가합니다.
+   - 예) `/analyze/upload?uiTest=1&scenario=happy-path`
+2. 또는 개발자 도구에서 `localStorage.setItem('gravifox:analyze:uiTest', '1')`을 실행합니다.
+   - `localStorage.removeItem('gravifox:analyze:uiTest')`로 해제할 수 있습니다.
+
+시나리오는 `scenario` 쿼리나 `localStorage.setItem('gravifox:analyze:uiTestScenario', '<scenario>')`로 지정할 수 있습니다. 쿼리 값이 우선 적용되며, 지정하지 않으면 마지막에 사용한 시나리오가 유지됩니다.
+
+## 지원 시나리오
+
+| 시나리오 키 | 설명 | 기본 jobIds |
+| --- | --- | --- |
+| `happy-path` | 두 개의 업로드가 모두 성공해 리포트를 확인할 수 있어요. | `demo-happy-1,demo-happy-2` |
+| `partial-failure` | 첫 번째는 성공, 두 번째는 실패 메시지가 표시돼요. | `demo-partial-1,demo-partial-2` |
+| `upload-error` | 업로드 단계에서 오류가 발생해 분석이 시작되지 않아요. | (없음) |
+| `quota-exhausted` | 잔여 횟수가 0으로 표시돼 업로드 전에 차단돼요. | `demo-quota-1` |
+| `email-unverified` | 이메일 미인증 안내 모달을 확인할 수 있어요. | `demo-email-1` |
+
+### 결과 화면 바로 보기
+
+업로드 단계를 거치지 않고도 세션 스토리지에 더미 데이터가 채워집니다. 아래 예시처럼 접근하면 곧바로 결과 화면을 확인할 수 있어요.
+
+```
+/analyze/result?uiTest=1&scenario=partial-failure&jobIds=demo-partial-1,demo-partial-2
+```
+
+시나리오에서 정의한 `jobIds`를 사용하면 컨텍스트가 세션 스토리지에 리포트/실패 데이터를 자동으로 기록해 기존 UI 로직이 그대로 작동합니다.
+
+## 참고
+
+- 테스트 모드에서는 모델 목록, 잔여 쿼터, 업로드 응답이 모두 즉시 반환되는 더미 데이터로 대체돼요.
+- 실서비스 모드로 돌아가려면 `uiTest=0` 쿼리를 추가하거나, 위에 안내한 로컬 스토리지 키를 삭제하세요.

--- a/src/App.js
+++ b/src/App.js
@@ -1,16 +1,19 @@
-import { BrowserRouter as Router} from "react-router-dom";
-import {AuthProvider} from "providers/authProvider";
+import { BrowserRouter as Router } from "react-router-dom";
+import { Suspense } from 'react';
+import { AuthProvider } from "providers/authProvider";
 import CustomRoutes from "routes/routes";
+import { AnalyzeFlowProvider } from './features/analyze/contexts/AnalyzeFlowContext';
 import "output.css";
 import './i18n';
-import { Suspense } from 'react';
 
 function App() {
     return (
         <AuthProvider>
             <Router>
-                <Suspense fallback={<div />}> 
-                    <CustomRoutes/>
+                <Suspense fallback={<div />}>
+                    <AnalyzeFlowProvider>
+                        <CustomRoutes/>
+                    </AnalyzeFlowProvider>
                 </Suspense>
             </Router>
         </AuthProvider>

--- a/src/features/analyze/contexts/AnalyzeFlowContext.js
+++ b/src/features/analyze/contexts/AnalyzeFlowContext.js
@@ -1,0 +1,527 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { ANALYZE_MODEL_ENDPOINTS } from '../../../api/endPointRoute';
+import { fetchQuotaSummary as fetchQuotaSummaryReal } from '../api/quotaSummary';
+import submitAnalyzeFilesReal from '../api/submitAnalyze';
+import { buildStoredFailure, buildStoredReport } from '../../../utils/reportStorage';
+import { normalizeAnalysisResult } from '../utils/normalizeResult';
+
+const TEST_FLAG_STORAGE_KEY = 'gravifox:analyze:uiTest';
+const TEST_SCENARIO_STORAGE_KEY = 'gravifox:analyze:uiTestScenario';
+const DEFAULT_SCENARIO_KEY = 'happy-path';
+
+const PLACEHOLDER_FACE_JPEG_BASE64 =
+  '/9j/4AAQSkZJRgABAQAAAQABAAD/2wCEAAkGBxISEhUQEhIVFRUVFRUVFRUVFRUVFRUVFhUVFRUYHSggGBolHRUVITEhJSkrLi4uFx8zODMtNygtLisBCgoKDg0OGxAQGy0lICYtLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLS0tLf/AABEIAKgBLAMBIgACEQEDEQH/xAAbAAEAAgMBAQAAAAAAAAAAAAAABQYCAwQBB//EADoQAAEDAgQDBgUEAwAAAAAAAAEAAgMEBREhBhMxQVEHEyJhcYGRMkJSobHB0TNTkrLC4fAVM4L/xAAYAQEBAQEBAAAAAAAAAAAAAAAAAQIDBP/EAB4RAQEAAgMBAQEAAAAAAAAAAAABAhESAyExBBNR/9oADAMBAAIRAxEAPwD8QAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAP/Z';
+
+const PLACEHOLDER_PREVIEW_DATA_URL = `data:image/jpeg;base64,${PLACEHOLDER_FACE_JPEG_BASE64}`;
+
+const BASE_MODELS_RESPONSE = Object.freeze({
+  updatedAt: '2024-05-22T00:00:00Z',
+  defaultKey: 'vision-lite',
+  items: [
+    {
+      key: 'vision-lite',
+      name: 'Vision Lite',
+      description: '가장 빠른 실시간 분석 모델',
+    },
+    {
+      key: 'vision-pro',
+      name: 'Vision Pro',
+      description: '고해상도 이미지에 최적화된 프리미엄 모델',
+    },
+    {
+      key: 'vision-guard',
+      name: 'Vision Guard',
+      description: '조작 흔적 탐지에 특화된 실험적 모델',
+    },
+  ],
+});
+
+const TEST_SCENARIOS = Object.freeze({
+  'happy-path': {
+    label: '성공 경로',
+    quotaSummary: {
+      planName: 'Pro',
+      limit: 30,
+      used: 12,
+      remaining: 18,
+      periodStart: '2024-05-01T00:00:00Z',
+      periodEnd: '2024-05-31T23:59:59Z',
+      loginType: 'EMAIL',
+      emailVerified: true,
+    },
+    modelsResponse: BASE_MODELS_RESPONSE,
+    remainingAfterSubmit: 17,
+    jobBlueprints: [
+      {
+        jobId: 'demo-happy-1',
+        meta: {
+          name: 'press-photo.jpg',
+          size: 542123,
+          type: 'image/jpeg',
+          modelKey: 'vision-lite',
+          previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+        },
+        result: {
+          label: 'REAL',
+          pAi: 0.18,
+          pReal: 0.82,
+          threshold: 0.5,
+          confidence: 0.82,
+          latency_sec: 2.4,
+          runtime: {
+            backend: 'TensorRT',
+            device: 'A10G',
+          },
+          faces: {
+            samples: [
+              {
+                image_jpg_base64: PLACEHOLDER_FACE_JPEG_BASE64,
+              },
+            ],
+          },
+        },
+      },
+      {
+        jobId: 'demo-happy-2',
+        meta: {
+          name: 'ai-suspect.png',
+          size: 781245,
+          type: 'image/png',
+          modelKey: 'vision-pro',
+          previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+        },
+        result: {
+          label: 'FAKE',
+          pAi: 0.91,
+          pReal: 0.09,
+          threshold: 0.5,
+          confidence: 0.94,
+          latency_sec: 4.1,
+          runtime: {
+            backend: 'ONNXRuntime',
+            device: 'A100',
+          },
+          faces: {
+            samples: [
+              {
+                image_jpg_base64: PLACEHOLDER_FACE_JPEG_BASE64,
+              },
+            ],
+          },
+        },
+      },
+    ],
+  },
+  'partial-failure': {
+    label: '부분 실패',
+    quotaSummary: {
+      planName: 'Starter',
+      limit: 10,
+      used: 4,
+      remaining: 6,
+      periodStart: '2024-05-01T00:00:00Z',
+      periodEnd: '2024-05-31T23:59:59Z',
+      loginType: 'EMAIL',
+      emailVerified: true,
+    },
+    modelsResponse: BASE_MODELS_RESPONSE,
+    remainingAfterSubmit: 5,
+    jobBlueprints: [
+      {
+        jobId: 'demo-partial-1',
+        meta: {
+          name: 'outdoor-photo.jpg',
+          size: 623000,
+          type: 'image/jpeg',
+          modelKey: 'vision-lite',
+          previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+        },
+        result: {
+          label: 'REAL',
+          pAi: 0.26,
+          pReal: 0.74,
+          threshold: 0.5,
+          confidence: 0.78,
+          latency_sec: 3.5,
+          runtime: {
+            backend: 'TensorRT',
+            device: 'L4',
+          },
+        },
+      },
+      {
+        jobId: 'demo-partial-2',
+        meta: {
+          name: 'blurry-shot.png',
+          size: 412000,
+          type: 'image/png',
+          modelKey: 'vision-guard',
+          previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+        },
+        error: 'AI 결과 생성 중 오류가 발생했어요. 다시 시도해 주세요.',
+      },
+    ],
+  },
+  'upload-error': {
+    label: '업로드 오류',
+    quotaSummary: {
+      planName: 'Starter',
+      limit: 10,
+      used: 1,
+      remaining: 9,
+      periodStart: '2024-05-01T00:00:00Z',
+      periodEnd: '2024-05-31T23:59:59Z',
+      loginType: 'EMAIL',
+      emailVerified: true,
+    },
+    modelsResponse: BASE_MODELS_RESPONSE,
+    submitErrors: ['업로드 토큰 발급에 실패했어요. 잠시 후 다시 시도해 주세요.'],
+    jobBlueprints: [],
+  },
+  'quota-exhausted': {
+    label: '쿼터 소진',
+    quotaSummary: {
+      planName: 'Starter',
+      limit: 10,
+      used: 10,
+      remaining: 0,
+      periodStart: '2024-05-01T00:00:00Z',
+      periodEnd: '2024-05-31T23:59:59Z',
+      loginType: 'EMAIL',
+      emailVerified: true,
+    },
+    modelsResponse: BASE_MODELS_RESPONSE,
+    jobBlueprints: [
+      {
+        jobId: 'demo-quota-1',
+        meta: {
+          name: 'quota-lock.png',
+          size: 382000,
+          type: 'image/png',
+          modelKey: 'vision-lite',
+          previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+        },
+        result: {
+          label: 'REAL',
+          pAi: 0.12,
+          pReal: 0.88,
+          threshold: 0.5,
+          confidence: 0.83,
+        },
+      },
+    ],
+  },
+  'email-unverified': {
+    label: '이메일 미인증',
+    quotaSummary: {
+      planName: 'Starter',
+      limit: 10,
+      used: 3,
+      remaining: 7,
+      periodStart: '2024-05-01T00:00:00Z',
+      periodEnd: '2024-05-31T23:59:59Z',
+      loginType: 'EMAIL',
+      emailVerified: false,
+    },
+    modelsResponse: BASE_MODELS_RESPONSE,
+    jobBlueprints: [
+      {
+        jobId: 'demo-email-1',
+        meta: {
+          name: 'verification-needed.png',
+          size: 298000,
+          type: 'image/png',
+          modelKey: 'vision-lite',
+          previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+        },
+        result: {
+          label: 'REAL',
+          pAi: 0.35,
+          pReal: 0.65,
+          threshold: 0.5,
+          confidence: 0.7,
+        },
+      },
+    ],
+  },
+});
+
+const AnalyzeFlowContext = createContext({
+  isTestMode: false,
+  scenarioKey: DEFAULT_SCENARIO_KEY,
+  fetchQuotaSummary: fetchQuotaSummaryReal,
+  fetchModels: async () => {
+    const response = await fetch(ANALYZE_MODEL_ENDPOINTS.LIST);
+    if (!response.ok) {
+      const detail = await safeJson(response);
+      const reason = detail?.message || detail?.error || '모델 목록을 불러오지 못했어요.';
+      throw new Error(reason);
+    }
+    return response.json();
+  },
+  submitAnalyzeFiles: submitAnalyzeFilesReal,
+  ensureTestReports: () => {},
+});
+
+function safeJson(response) {
+  try {
+    return response.json();
+  } catch {
+    return null;
+  }
+}
+
+function clone(value) {
+  if (value == null) return value;
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+}
+
+function readStoredFlag(key) {
+  try {
+    return typeof window !== 'undefined' ? window.localStorage.getItem(key) : null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStoredFlag(key, value) {
+  try {
+    if (typeof window === 'undefined') return;
+    if (value == null) {
+      window.localStorage.removeItem(key);
+    } else {
+      window.localStorage.setItem(key, value);
+    }
+  } catch {}
+}
+
+function getScenarioConfig(key) {
+  return TEST_SCENARIOS[key] || TEST_SCENARIOS[DEFAULT_SCENARIO_KEY];
+}
+
+function ensureSessionValue(key, value) {
+  try {
+    if (typeof window === 'undefined') return;
+    if (value == null) {
+      window.sessionStorage.removeItem(key);
+    } else {
+      window.sessionStorage.setItem(key, value);
+    }
+  } catch {}
+}
+
+async function fetchModelsReal() {
+  const response = await fetch(ANALYZE_MODEL_ENDPOINTS.LIST);
+  if (!response.ok) {
+    const detail = await safeJson(response);
+    const reason = detail?.message || detail?.error || '모델 목록을 불러오지 못했어요.';
+    throw new Error(reason);
+  }
+  return response.json();
+}
+
+function useTestState(locationSearch) {
+  return useMemo(() => {
+    if (typeof window === 'undefined') {
+      return { isTestMode: false, scenarioKey: DEFAULT_SCENARIO_KEY };
+    }
+    const params = new URLSearchParams(locationSearch || window.location.search || '');
+    const queryFlag = params.get('uiTest');
+    const enabledFromQuery = queryFlag != null && ['1', 'true'].includes(queryFlag.toLowerCase());
+    const disabledFromQuery = queryFlag != null && ['0', 'false'].includes(queryFlag.toLowerCase());
+    if (enabledFromQuery) {
+      writeStoredFlag(TEST_FLAG_STORAGE_KEY, '1');
+    } else if (disabledFromQuery) {
+      writeStoredFlag(TEST_FLAG_STORAGE_KEY, null);
+    }
+    const storedFlag = readStoredFlag(TEST_FLAG_STORAGE_KEY);
+    const isTestMode = enabledFromQuery || (!disabledFromQuery && storedFlag === '1');
+
+    let scenarioKey = DEFAULT_SCENARIO_KEY;
+    if (isTestMode) {
+      const requestedScenario = params.get('scenario');
+      if (requestedScenario && TEST_SCENARIOS[requestedScenario]) {
+        scenarioKey = requestedScenario;
+        writeStoredFlag(TEST_SCENARIO_STORAGE_KEY, scenarioKey);
+      } else {
+        const storedScenario = readStoredFlag(TEST_SCENARIO_STORAGE_KEY);
+        if (storedScenario && TEST_SCENARIOS[storedScenario]) {
+          scenarioKey = storedScenario;
+        }
+      }
+    }
+
+    if (!isTestMode) {
+      writeStoredFlag(TEST_SCENARIO_STORAGE_KEY, null);
+    }
+
+    return { isTestMode, scenarioKey };
+  }, [locationSearch]);
+}
+
+async function submitAnalyzeFilesTest(files, options = {}, scenarioKey) {
+  const scenario = getScenarioConfig(scenarioKey);
+  const submitErrors = Array.isArray(scenario.submitErrors) ? [...scenario.submitErrors] : [];
+
+  if (submitErrors.length > 0) {
+    return { jobIds: [], errors: submitErrors, remainingQuota: scenario.quotaSummary?.remaining ?? null };
+  }
+
+  const list = Array.isArray(files) ? [...files] : [];
+  const jobBlueprints = Array.isArray(scenario.jobBlueprints) ? scenario.jobBlueprints : [];
+  const jobs = [];
+
+  const count = list.length > 0 ? list.length : jobBlueprints.length;
+  if (count === 0) {
+    return { jobIds: [], errors: [], remainingQuota: scenario.quotaSummary?.remaining ?? null };
+  }
+
+  for (let idx = 0; idx < count; idx += 1) {
+    const file = list[idx];
+    const blueprint = jobBlueprints[idx] || jobBlueprints[jobBlueprints.length - 1] || jobBlueprints[0];
+    if (!blueprint) {
+      break;
+    }
+    const jobId = blueprint.jobId || `demo-job-${idx + 1}`;
+    const baseMeta = clone(blueprint.meta) || {};
+    if (file) {
+      baseMeta.name = file?.name || baseMeta.name || `테스트-${idx + 1}.jpg`;
+      baseMeta.size = file?.size ?? baseMeta.size ?? 0;
+      baseMeta.type = file?.type || baseMeta.type || 'image/jpeg';
+    }
+    if (!baseMeta.modelKey && typeof options?.modelKey === 'string') {
+      baseMeta.modelKey = options.modelKey;
+    }
+    if (typeof options?.buildMeta === 'function' && file) {
+      try {
+        const extraMetaMaybe = options.buildMeta(file, { uploadId: `demo-upload-${idx + 1}` });
+        const extraMeta = extraMetaMaybe && typeof extraMetaMaybe.then === 'function' ? await extraMetaMaybe : extraMetaMaybe;
+        if (extraMeta && typeof extraMeta === 'object') {
+          Object.assign(baseMeta, extraMeta);
+        }
+      } catch {}
+    }
+
+    ensureSessionValue(`sse:meta:${jobId}`, JSON.stringify(baseMeta));
+    ensureSessionValue(`sse:${jobId}`, null);
+
+    if (blueprint.error) {
+      ensureSessionValue(
+        `sse:failed:${jobId}`,
+        JSON.stringify(buildStoredFailure(blueprint.error, baseMeta))
+      );
+      ensureSessionValue(`sse:report:${jobId}`, null);
+    } else {
+      const normalized = normalizeAnalysisResult(clone(blueprint.result) || {});
+      ensureSessionValue(
+        `sse:report:${jobId}`,
+        JSON.stringify(buildStoredReport(normalized, baseMeta))
+      );
+      ensureSessionValue(`sse:failed:${jobId}`, null);
+    }
+
+    jobs.push(jobId);
+  }
+
+  const remainingQuota = typeof scenario.remainingAfterSubmit === 'number'
+    ? scenario.remainingAfterSubmit
+    : typeof scenario.quotaSummary?.remaining === 'number'
+    ? Math.max(0, scenario.quotaSummary.remaining - jobs.length)
+    : null;
+
+  return { jobIds: jobs, errors: [], remainingQuota };
+}
+
+function ensureScenarioReports(jobIds, scenarioKey) {
+  const scenario = getScenarioConfig(scenarioKey);
+  if (!Array.isArray(jobIds) || jobIds.length === 0) return;
+  const blueprints = Array.isArray(scenario.jobBlueprints) ? scenario.jobBlueprints : [];
+  jobIds.forEach((jobId, idx) => {
+    if (!jobId) return;
+    const existingReport = typeof window !== 'undefined' ? window.sessionStorage.getItem(`sse:report:${jobId}`) : null;
+    const existingFailure = typeof window !== 'undefined' ? window.sessionStorage.getItem(`sse:failed:${jobId}`) : null;
+    if (existingReport || existingFailure) return;
+    const blueprint = blueprints.find((item) => item.jobId === jobId) || blueprints[idx] || blueprints[0];
+    if (!blueprint) return;
+    const meta = clone(blueprint.meta) || {
+      name: `테스트-${idx + 1}.jpg`,
+      type: 'image/jpeg',
+      size: 0,
+      modelKey: scenario.modelsResponse?.defaultKey || 'vision-lite',
+      previewDataUrl: PLACEHOLDER_PREVIEW_DATA_URL,
+    };
+    ensureSessionValue(`sse:meta:${jobId}`, JSON.stringify(meta));
+    ensureSessionValue(`sse:${jobId}`, null);
+    if (blueprint.error) {
+      ensureSessionValue(
+        `sse:failed:${jobId}`,
+        JSON.stringify(buildStoredFailure(blueprint.error, meta))
+      );
+      ensureSessionValue(`sse:report:${jobId}`, null);
+    } else {
+      const normalized = normalizeAnalysisResult(clone(blueprint.result) || {});
+      ensureSessionValue(
+        `sse:report:${jobId}`,
+        JSON.stringify(buildStoredReport(normalized, meta))
+      );
+      ensureSessionValue(`sse:failed:${jobId}`, null);
+    }
+  });
+}
+
+export function AnalyzeFlowProvider({ children }) {
+  const location = useLocation();
+  const derived = useTestState(location?.search || '');
+  const [isTestMode, setIsTestMode] = useState(derived.isTestMode);
+  const [scenarioKey, setScenarioKey] = useState(derived.scenarioKey);
+
+  useEffect(() => {
+    setIsTestMode(derived.isTestMode);
+    setScenarioKey(derived.scenarioKey);
+  }, [derived.isTestMode, derived.scenarioKey]);
+
+  const ensureTestReports = useCallback(
+    (jobIds) => {
+      if (!isTestMode) return;
+      ensureScenarioReports(jobIds, scenarioKey);
+    },
+    [isTestMode, scenarioKey]
+  );
+
+  const contextValue = useMemo(() => {
+    if (!isTestMode) {
+      return {
+        isTestMode: false,
+        scenarioKey,
+        fetchQuotaSummary: fetchQuotaSummaryReal,
+        fetchModels: fetchModelsReal,
+        submitAnalyzeFiles: submitAnalyzeFilesReal,
+        ensureTestReports,
+      };
+    }
+
+    const scenario = getScenarioConfig(scenarioKey);
+
+    return {
+      isTestMode: true,
+      scenarioKey,
+      fetchQuotaSummary: async () => clone(scenario.quotaSummary),
+      fetchModels: async () => clone(scenario.modelsResponse),
+      submitAnalyzeFiles: (files, options = {}) => submitAnalyzeFilesTest(files, options, scenarioKey),
+      ensureTestReports,
+    };
+  }, [ensureTestReports, isTestMode, scenarioKey]);
+
+  return <AnalyzeFlowContext.Provider value={contextValue}>{children}</AnalyzeFlowContext.Provider>;
+}
+
+export function useAnalyzeFlow() {
+  return useContext(AnalyzeFlowContext);
+}
+
+export default AnalyzeFlowContext;

--- a/src/pages/MobileAnalyzeResult.js
+++ b/src/pages/MobileAnalyzeResult.js
@@ -9,6 +9,7 @@ import { ANALYZE_ENDPOINTS } from '../api/endPointRoute';
 import MobileAnalysisReport from '../features/analyze/components/mobile/MobileAnalysisReport';
 import { normalizeAnalysisResult } from '../features/analyze/utils/normalizeResult';
 import { buildStoredFailure, buildStoredReport, parseStoredFailure, parseStoredReport } from '../utils/reportStorage';
+import { useAnalyzeFlow } from '../features/analyze/contexts/AnalyzeFlowContext';
 
 const IS_TEST_ENV = String(process.env.NODE_ENV || '').toLowerCase() === 'test';
 const TEST_TIMEOUT_MS = 10_000;
@@ -99,6 +100,7 @@ export default function MobileAnalyzeResult() {
   const { lng } = useParams();
   const { search } = useLocation();
   const params = useMemo(() => new URLSearchParams(search), [search]);
+  const { isTestMode, ensureTestReports } = useAnalyzeFlow();
   const jobIds = useMemo(() => {
     const csv = params.get('jobIds');
     if (!csv) return [];
@@ -115,10 +117,13 @@ export default function MobileAnalyzeResult() {
 
   useEffect(() => {
     if (!jobIds.length) return;
+    if (isTestMode) {
+      ensureTestReports(jobIds);
+    }
     const sources = [];
     const timeouts = [];
     jobIds.forEach((jid) => {
-      const token = sessionStorage.getItem(`sse:${jid}`);
+      const token = isTestMode ? null : sessionStorage.getItem(`sse:${jid}`);
       const metaStr = sessionStorage.getItem(`sse:meta:${jid}`);
       let fileMeta = null;
       try {
@@ -293,7 +298,7 @@ export default function MobileAnalyzeResult() {
         if (timer) clearTimeout(timer);
       });
     };
-  }, [jobIds, t]);
+  }, [ensureTestReports, isTestMode, jobIds, t]);
 
   const analysisStates = useMemo(
     () => jobIds.map((jid) => ({ jobId: jid, ...(reports[jid] || {}) })),

--- a/src/pages/MobileAnalyzeUpload.js
+++ b/src/pages/MobileAnalyzeUpload.js
@@ -5,12 +5,10 @@ import { UploadCloud, ChevronRight, LifeBuoy } from 'lucide-react';
 import Navigation from '../features/navigation/navigation';
 import Footer from '../features/footer/footer';
 import ErrorModal from '../features/analyze/components/ErrorModal';
-import { ANALYZE_MODEL_ENDPOINTS } from '../api/endPointRoute';
-import submitAnalyzeFiles from '../features/analyze/api/submitAnalyze';
-import { fetchQuotaSummary } from '../features/analyze/api/quotaSummary';
 import LoginRequiredModal from '../features/analyze/components/LoginRequiredModal';
 import { useAuth } from 'providers/authProvider';
 import { readFileAsDataURL } from '../utils/filePreview';
+import { useAnalyzeFlow } from '../features/analyze/contexts/AnalyzeFlowContext';
 import {
   rememberReturnCheckpoint,
   clearReturnCheckpoint,
@@ -110,6 +108,7 @@ export default function MobileAnalyzeUpload() {
   const { lng } = useParams();
   const location = useLocation();
   const { accessToken, userInfo } = useAuth();
+  const { fetchQuotaSummary: resolveQuotaSummary, fetchModels, submitAnalyzeFiles: runSubmitAnalyze } = useAnalyzeFlow();
 
   const [files, setFiles] = useState([]);
   const [errorOpen, setErrorOpen] = useState(false);
@@ -178,7 +177,7 @@ export default function MobileAnalyzeUpload() {
     }
     setLoadingQuota(true);
     try {
-      const summary = await fetchQuotaSummary();
+      const summary = await resolveQuotaSummary();
       setQuotaSummary(summary);
     } catch (error) {
       if (error?.status === 401) {
@@ -187,7 +186,7 @@ export default function MobileAnalyzeUpload() {
     } finally {
       setLoadingQuota(false);
     }
-  }, [accessToken]);
+  }, [accessToken, resolveQuotaSummary]);
 
   useEffect(() => {
     if (accessToken) {
@@ -209,7 +208,7 @@ export default function MobileAnalyzeUpload() {
     }
     setLoadingQuota(true);
     try {
-      const summary = await fetchQuotaSummary();
+      const summary = await resolveQuotaSummary();
       setQuotaSummary(summary);
 
       if (summary?.loginType === 'EMAIL' && !summary?.emailVerified) {
@@ -243,17 +242,13 @@ export default function MobileAnalyzeUpload() {
     } finally {
       setLoadingQuota(false);
     }
-  }, [t, userInfo]);
+  }, [resolveQuotaSummary, t, userInfo]);
   useEffect(() => {
     let aborted = false;
     const loadModels = async () => {
       setLoadingModels(true);
       try {
-        const response = await fetch(ANALYZE_MODEL_ENDPOINTS.LIST);
-        if (!response.ok) {
-          throw new Error(t('mobileAnalyze.uploadPage.modelFetchError', '모델 목록을 불러오지 못했어요.'));
-        }
-        const data = await response.json();
+        const data = await fetchModels();
         if (aborted) return;
         const items = Array.isArray(data?.items) ? data.items : [];
         setModels(items);
@@ -278,7 +273,7 @@ export default function MobileAnalyzeUpload() {
     return () => {
       aborted = true;
     };
-  }, [t]);
+  }, [fetchModels, t]);
 
   useEffect(() => {
     if (!sampleRequested || sampleAutoFillRef.current || files.length > 0) {
@@ -427,7 +422,7 @@ export default function MobileAnalyzeUpload() {
     setPendingResultPath(null);
     let stayOnPage = false;
     try {
-      const { jobIds, errors, remainingQuota } = await submitAnalyzeFiles(files, {
+      const { jobIds, errors, remainingQuota } = await runSubmitAnalyze(files, {
         modelKey,
         buildMeta: async (file) => {
           const base = {


### PR DESCRIPTION
## 변경 목적
- 분석 업로드/결과 플로우를 실제 API 없이도 안정적으로 데모하고 테스트할 수 있도록 했어요.

## 주요 변경점
- AnalyzeFlowContext를 추가해 실서비스/테스트 모드에 따라 API 호출 또는 더미 데이터를 주입했어요.
- App 루트에서 AnalyzeFlowProvider로 라우터를 감싸고 쿼리·로컬 스토리지를 읽어 테스트 모드를 자동으로 감지하도록 했어요.
- 모바일 업로드/결과 페이지에서 컨텍스트를 활용해 쿼터, 모델, 업로드, SSE 로직을 테스트 모드에서도 작동하게 만들었어요.
- 테스트 시나리오와 사용 방법을 정리한 `docs/analyze-ui-test-guide.md` 문서를 추가했어요.

## 테스트 결과 요약
- `npm test -- --watch=false`를 실행해 변경된 파일과 관련된 테스트가 통과했어요.

## 보안·성능 고려사항
- 테스트 모드는 클라이언트 더미 데이터를 사용해 추가적인 보안 이슈나 성능 저하는 없어요.

## 관련 이슈 번호
- 없음


------
https://chatgpt.com/codex/tasks/task_e_68ed305f28fc8323a037e33aab135f8b